### PR TITLE
hotfix: temporarily remove es6 syntax

### DIFF
--- a/routes/comments.js
+++ b/routes/comments.js
@@ -1,6 +1,6 @@
-import repliesRoutes from "./replies";
+const repliesRoutes = require("./replies");
 const router = require("express").Router();
 
 router.use("/comments/replies", repliesRoutes);
 
-export default router;
+module.exports = router;

--- a/server.js
+++ b/server.js
@@ -3,7 +3,7 @@ const cookieParser = require("cookie-parser");
 const logger = require("morgan");
 const mongoose = require("mongoose");
 const cors = require("cors");
-import commentRoutes from "./routes/comments";
+const commentRoutes = require("./routes/comments");
 const documentationRoutes = require("./routes/documentation");
 const CustomError = require("./utils/customError");
 const errorHandler = require("./utils/errorhandler");


### PR DESCRIPTION
**Before submitting your PR for review**

- Run `npm run lint` to find errors in code syntax/format
- Run `npm run lint:fix` to fix all auto-fixable errors in source code and auto-format with prettier
- Ensure you fix any linting errors displayed after running any of the above commands

**What does this PR do?**
ES6 syntax is causing the app to crash on heroku since we are not using babel-node in production. This has been removed temporarily until the app is refcactored to accommodate building ES6 modules