### PR TITLE
feat: added the functionality for users to fag off comments

### DIFF
--- a/controller/commentsController.js
+++ b/controller/commentsController.js
@@ -1,5 +1,52 @@
 // UNCOMMENT EACH MODEL HERE AS NEEDED
 
 // const Replies = require("../models/replies");
-// const Comments = require("../models/comments");
+const Comments = require("../models/comments");
 // const User = require("../models/users");
+const errHandler = require("../utils/errorhandler");
+const mongoose = require("mongoose");
+
+exports.flagComment = async (req, res) => {
+  try {
+    const { commentId } = req.params;
+    const comment = await Comments.findOneAndUpdate(
+      {
+        _id: commentId,
+      },
+      {
+        isFlagged: true,
+        $inc: {
+          numOfFlags: 1,
+        },
+      },
+      {
+        new: true,
+      }
+    );
+    if (!mongoose.Types.ObjectId.isValid(commentId)) {
+      return res.status(422).json({
+        status: "error",
+        response: "422 error",
+        message: "Invalid ID",
+      });
+    }
+    if (!comment) {
+      return res.status(404).json({
+        status: "error",
+        message: `Comment with the ID ${commentId} doesn't exist or has been deleted`,
+        data: null,
+      });
+    }
+    return res.status(200).json({
+      message: "Comment has been flagged successfully",
+      response: "200 OK",
+      data: {
+        commentId: comment._id,
+        isFlagged: comment.isFlagged,
+        numOfflags: comment.numOfFlags,
+      },
+    });
+  } catch (error) {
+    errHandler(error, res);
+  }
+};

--- a/routes/comments.js
+++ b/routes/comments.js
@@ -1,6 +1,8 @@
 const repliesRoutes = require("./replies");
 const router = require("express").Router();
+const commentController = require("../controller/commentsController");
 
 router.use("/comments/replies", repliesRoutes);
 
+router.patch("/:commentId/flag", commentController.flagComment);
 module.exports = router;


### PR DESCRIPTION
**Before submitting your PR for review**

- Run `npm run lint` to find errors in code syntax/format
- Run `npm run lint:fix` to fix all auto-fixable errors in source code and auto-format with prettier
- Ensure you fix any linting errors displayed after running any of the above commands

**What does this PR do?**
- This PR contains the controller and route for a user to flag off a comment by its ID and increment it in the database as described in the documentation

**description of Task to be completed?**
- I am available for any tasks related or unrealted to this

Describe (in detail) what the task completed in the pull request does as per the relevant task

**How should this be manually tested?**
- this can be tested by hitting the endpoint `/comments/{commentID}/flag ` with a **patch** http verb

Give bullet point instructions on how to setup the code and test it manually (Assume no prior experience on JS or code)

**Any background context you want to provide?**

Any pertinent information that should be considered

**What is the link to the issue on Github?**

[Issue #64](https://github.com/microapidev/comment-microapi/issues/64)

**Questions:**

If something is unclear or you want some questions to be addressed by your peers, mention them here