### PR TITLE
ISSUE 9 initial solution //airon

### DIFF
--- a/controller/commentsController.js
+++ b/controller/commentsController.js
@@ -1,9 +1,8 @@
 // UNCOMMENT EACH MODEL HERE AS NEEDED
 
-// const Replies = require("../models/replies");
-
+const Replies = require("../models/replies");
 const Comments = require("../models/comments");
-// const User = require("../models/users");
+const User = require("../models/users");
 const errHandler = require("../utils/errorhandler");
 const mongoose = require("mongoose");
 
@@ -50,4 +49,81 @@ exports.flagComment = async (req, res) => {
   } catch (error) {
     errHandler(error, res);
   }
+};
+
+exports.getComments = async (req, res, next) => {
+  const origin = req.query.origin;
+  try {
+    await Comments.find({ commentOrigin: origin })
+      .populate("replies")
+      .populate("users")
+      .then((comments) => {
+        res.status(200).json({
+          status: "success",
+          message: `Comments Retrieved Successfully for ${origin}`,
+          data: comments,
+        });
+      })
+      .catch(next);
+  } catch (err) {
+    res.status(401).json({
+      status: "error",
+      message: `Something went wrong`,
+      data: err,
+    });
+  }
+};
+
+exports.getFlaggedComments = async (req, res, next) => {
+  const origin = req.query.origin;
+  try {
+    await Comments.find({ commentOrigin: origin, isFlagged: true })
+      .populate("replies")
+      .populate("users")
+      .then((comments) => {
+        res.status(200).json({
+          status: "success",
+          message: `Flagged Comments Retrieved Successfully for ${origin}`,
+          data: comments,
+        });
+      })
+      .catch(next);
+  } catch (err) {
+    res.status(401).json({
+      status: "error",
+      message: `Something went wrong`,
+      data: err,
+    });
+  }
+};
+
+exports.getUnFlaggedComments = async (req, res, next) => {
+  const origin = req.query.origin;
+  try {
+    await Comments.find({ commentOrigin: origin, isFlagged: false })
+      .populate("replies")
+      .populate("users")
+      .then((comments) => {
+        res.status(200).json({
+          status: "success",
+          message: `Unflagged Comments Retrieved Successfully for ${origin}`,
+          data: comments,
+        });
+      })
+      .catch(next);
+  } catch (err) {
+    res.status(401).json({
+      status: "error",
+      message: `Something went wrong`,
+      data: err,
+    });
+  }
+};
+
+// Nothing is happening here for now - just to avoid lint errors
+exports.unusedMethod = async () => {
+  let user = new User({});
+  let reply = new Replies({});
+  user.save();
+  reply.save();
 };

--- a/routes/comments.js
+++ b/routes/comments.js
@@ -1,8 +1,26 @@
 const repliesRoutes = require("./replies");
 const router = require("express").Router();
 const commentController = require("../controller/commentsController");
-
+const commentsController = require("../controller/commentsController");
 router.use("/:commentId/replies", repliesRoutes);
 
 router.patch("/:commentId/flag", commentController.flagComment);
+
+// Single configurable  route to get all comments, flagged and unflagged comments
+// My intention was to use express-validate package, but couldn't get to work, I will look at this in the future
+router.get("/", function (req, res, next) {
+  // flagged comments can be retreived by passing a query string eg. /comments/?flagged or /comments/?flagged=true
+  if (req.query.flagged === "" || req.query.flagged === "true") {
+    return commentsController.getFlaggedComments(req, res, next);
+  }
+  // similarly unflagged comments can be retreived by passing a query string eg. /comments/?unflagged or /comments/?unflagged=true
+  if (req.query.unflagged === "" || req.query.unflagged === "true") {
+    return commentsController.getUnFlaggedComments(req, res, next);
+  }
+  // all comments can be retreived by not passing a query string eg. /comments/
+  else {
+    return commentsController.getComments(req, res, next);
+  }
+});
+
 module.exports = router;


### PR DESCRIPTION
**Before submitting your PR for review**

- Run `npm run lint` to find errors in code syntax/format
- Run `npm run lint:fix` to fix all auto-fixable errors in source code and auto-format with prettier
- Ensure you fix any linting errors displayed after running any of the above commands

**ISSUE #9?**
[FEATURE REQUEST] GET ALL COMMENTS ON A REPORT (INCLUDING FLAGGED COMMENTS) 
I created a single configurable  route to get 
- all comments, 
- flagged comments
- unflagged comments

**HOW TO TEST**
- Flagged comments can be retrieved by passing an origin  and flagged key as query params eg. /comments/?origin=123123&flagged  OR   /comments/?origin=123123&flagged=true
- Unflagged comments can be retrieved by passing an origin and unflagged key as query params  eg. /comments/?origin=123123&unflagged OR  /comments/?origin=123123&unflagged=true
-  all comments can be retrieved by simply passing an origin key as query params  eg. /comments/?origin=123123

**LINK TO GITHUB ISSUE**
[Issue #9](https://github.com/microapidev/comment-microapi/issues/9)

**Questions:**
My current solution is based on the existing model structure, kindly notify me if any adjustment is required on this issue.
Thanks

**SLACK DETAILS**
- username: @airon
- email: airondev@gmail.com
- full-name: Aaron, Aniebiet B.