### PR TITLE
feat: add validation rules for endpoints

### DIFF
--- a/utils/validationRules.js
+++ b/utils/validationRules.js
@@ -1,0 +1,153 @@
+const Joi = require("@hapi/joi");
+
+const voteTypes = ["upvote", "downvote"];
+
+module.exports = {
+  /**
+   * Schema validation for GET '/comments'
+   */
+  getAllCommentsSchema: {
+    query: Joi.object({
+      isFlagged: Joi.boolean(),
+    }),
+  },
+
+  /**
+   * Schema validation for POST '/comments'
+   */
+  createCommentSchema: {
+    body: Joi.object().keys({
+      refId: Joi.string().min(1),
+      commentBody: Joi.string().min(1).required(),
+      commentOwnerName: Joi.string().min(1).required(),
+      commentOwnerEmail: Joi.string().email().required(),
+      coomentOrigin: Joi.string().required(),
+    }),
+  },
+
+  /**
+   * Schema validation for GET '/comments/refs/{refId}'
+   */
+  getAllCommentsOfReferenceSchema: {
+    query: Joi.object({
+      isFlagged: Joi.boolean(),
+    }),
+    params: Joi.object({
+      refId: Joi.string().required(),
+    }),
+  },
+
+  /**
+   * Schema validation for PATCH '/comments/{commentId}'
+   */
+  updateCommentSchema: {
+    params: Joi.object({
+      commentId: Joi.string().required(),
+    }),
+    body: Joi.object().keys({
+      commentBody: Joi.string().min(1).required(),
+      commentOwnerEmail: Joi.string().email().required(),
+    }),
+  },
+
+  /**
+   * Schema validation for DELETE '/comments/{commentId}'
+   */
+  deleteCommentSchema: {
+    params: Joi.object({
+      commentId: Joi.string().required(),
+    }),
+    body: Joi.object().keys({
+      commentOwnerEmail: Joi.string().email().required(),
+    }),
+  },
+
+  /**
+   * Schema validation for PATCH '/comments/{commentId}/votes'
+   */
+  updateCommentVoteSchema: {
+    params: Joi.object({
+      commentId: Joi.string().required(),
+    }),
+    body: Joi.object().keys({
+      voteType: Joi.string().allow(voteTypes).required(),
+    }),
+  },
+
+  /**
+   * Schema validation for PATCH '/comments/{commentId}/flag'
+   */
+  updateCommentFlagSchema: {
+    params: Joi.object({
+      commentId: Joi.string().required(),
+    }),
+    body: Joi.object().keys({
+      isFlagged: Joi.boolean().required(),
+    }),
+  },
+
+  /**
+   * Schema validation for GET '/comments/{commentId}/replies'
+   */
+  getAllCommentRepliesSchema: {
+    query: Joi.object({
+      isFlagged: Joi.boolean(),
+    }),
+    params: Joi.object({
+      commentId: Joi.string().required(),
+    }),
+  },
+
+  /**
+   * Schema validation for POST '/comments/{commentId}/replies'
+   */
+  createCommentReplySchema: {
+    params: Joi.object({
+      commentId: Joi.string().required(),
+    }),
+    body: Joi.object().keys({
+      replyBody: Joi.string().min(1).required(),
+      replyOwnerName: Joi.string().min(1).required(),
+      replyOwnerEmail: Joi.string().email().required(),
+    }),
+  },
+
+  /**
+   * Schema validation for DELETE '/comments/{commentId}/replies/{replyId}'
+   */
+  deleteCommentReplySchema: {
+    params: Joi.object({
+      commentId: Joi.string().required(),
+      replyId: Joi.string().required(),
+    }),
+    body: Joi.object().keys({
+      replyOwnerEmail: Joi.string().email().required(),
+    }),
+  },
+
+  /**
+   * Schema validation for PATCH '/comments/{commentId}/replies/{replyId}/votes'
+   */
+  updateCommentReplyVoteSchema: {
+    params: Joi.object({
+      commentId: Joi.string().required(),
+      replyId: Joi.string().required(),
+    }),
+    body: Joi.object().keys({
+      voteType: Joi.string().allow(voteTypes).required(),
+    }),
+  },
+
+  /**
+   * Schema validation for PATCH '/comments/{commentId}/replies/{replyId}/flag'
+   */
+  updateCommentReplyFlagSchema: {
+    params: Joi.object({
+      commentId: Joi.string().required(),
+      replyId: Joi.string().required(),
+    }),
+    body: Joi.object().keys({
+      isFlagged: Joi.boolean().required(),
+    }),
+  },
+};

--- a/utils/validationRules.js
+++ b/utils/validationRules.js
@@ -113,6 +113,20 @@ module.exports = {
   },
 
   /**
+   * Schema validation for PATCH '/comments/{commentId}/replies/{replyId}'
+   */
+  updateCommentReplySchema: {
+    params: Joi.object({
+      commentId: Joi.string().required(),
+      replyId: Joi.string().required(),
+    }),
+    body: Joi.object().keys({
+      replyBody: Joi.string().min(1).required(),
+      replyOwnerEmail: Joi.string().email().required(),
+    }),
+  },
+
+  /**
    * Schema validation for DELETE '/comments/{commentId}/replies/{replyId}'
    */
   deleteCommentReplySchema: {


### PR DESCRIPTION
**Before submitting your PR for review**

- Run `npm run lint` to find errors in code syntax/format
- Run `npm run lint:fix` to fix all auto-fixable errors in source code and auto-format with prettier
- Ensure you fix any linting errors displayed after running any of the above commands

**What does this PR do?**
- Uses the @hapi/joi npm package to define a schema of Javascript objects.
- Uses Joi's handy methods that come bundled with it, to validate any relevant params, body, query, or headers against the schema.

Additionally, the @hapi/joi package also creates detailed error messages for us so we don't have to write error messages again and again for every case.

**description of Task to be completed?**
- [x] Create validation schema for `GET /comments`
- [x] Create validation schema for `POST /comments`
- [x] Create validation schema for `GET /comments/refs/{refId}`
- [x] Create validation schema for `PATCH /comments/{commentId}`
- [x] Create validation schema for `DELETE /comments/{commentId}`
- [x] Create validation schema for `PATCH /comments/{commentId}/votes`
- [x] Create validation schema for `PATCH /comments/{commentId}/flag`
- [x] Create validation schema for `GET /comments/{commentId}/replies`
- [x] Create validation schema for `POST /comments/{commentId}/replies`
- [x] Create validation schema for `PATCH /comments/{commentId}/replies/{replyId}`
- [x] Create validation schema for `DELETE /comments/{commentId}/replies/{replyId}`
- [x] Create validation schema for `PATCH /comments/{commentId}/replies/{replyId}/votes`
- [x] Create validation schema for `PATCH /comments/{commentId}/replies/{replyId}/flag`

**How should this be manually tested?**
The tests will only be possible once the routes are all created and the validationMiddleware is used with the specific validation schema.

**Any background context you want to provide?**
None

**What is the link to the issue on Github?**

[Issue #13](https://github.com/microapidev/comment-microapi/issues/13)

**Questions:**
None