### PR TITLE
write tests for downvote and upvote of comments (#75)

### DIFF
--- a/__test__/api/comment-vote.test.js
+++ b/__test__/api/comment-vote.test.js
@@ -1,0 +1,76 @@
+const app = require("../../server");
+const supertest = require("supertest");
+const CommentModel = require("../../models/comments");
+const mongoose = require("mongoose");
+const request = supertest(app);
+import { skipIfNotFound } from "../helpers/conditionalTests";
+
+describe("PATCH '/comments/:commentId/votes'", () => {
+  skipIfNotFound("PATCH", "/comments/:commentId/votes");
+  test("Should upvote a comment", async () => {
+    const comment = new CommentModel({
+      commentBody: "this is a comment",
+      commentOwnerName: "userName",
+      commentOwnerEmail: "useremail@email.com",
+      commentOrigin: "123123",
+      commentOwner: mongoose.Types.ObjectId(),
+    });
+    await comment.save();
+
+    const res = await request.patch(`/comments/${comment._id}/votes`).send({
+      voteType: "upvote",
+    });
+    if (res.status === 404) {
+      return true; // route not implemented yet
+    }
+    expect(res.status).toBe(200);
+    expect(res.body.data.commentId).toBeTruthy();
+    expect(res.body.data.totalVotes).toBeTruthy();
+    expect(res.body.data.upvotes).toBeTruthy();
+    expect(res.body.data.downvotes).toBeTruthy();
+  });
+
+  test("Should downvote a comment", async () => {
+    const comment = new CommentModel({
+      commentBody: "this is a comment",
+      commentOwnerName: "userName",
+      commentOwnerEmail: "useremail2@email.com",
+      commentOrigin: "123123",
+      commentOwner: mongoose.Types.ObjectId(),
+    });
+    await comment.save();
+
+    const res = await request.patch(`/comments/${comment._id}/votes`).send({
+      voteType: "downvote",
+    });
+    if (res.status === 404) {
+      return true; // route not implemented yet
+    }
+    expect(res.status).toBe(200);
+    expect(res.body.data.commentId).toBeTruthy();
+    expect(res.body.data.totalVotes).toBeTruthy();
+    expect(res.body.data.upvotes).toBeTruthy();
+    expect(res.body.data.downvotes).toBeTruthy();
+  });
+
+  test("Should reject unknown vote type", async () => {
+    const comment = new CommentModel({
+      commentBody: "this is a comment",
+      commentOwnerName: "userName",
+      commentOwnerEmail: "useremail3@email.com",
+      commentOrigin: "123123",
+      commentOwner: mongoose.Types.ObjectId(),
+    });
+    await comment.save();
+
+    const res = await request.patch(`/comments/${comment._id}/votes`).send({
+      voteType: "invalid",
+    });
+    if (res.status === 404) {
+      return true; // route not implemented yet
+    }
+    expect(res.status).toBe(422);
+    expect(res.body.data.status).toBeTruthy();
+    expect(res.body.data.message).toBeTruthy();
+  });
+});


### PR DESCRIPTION
**Before submitting your PR for review**

- Run `npm run lint` to find errors in code syntax/format
- Run `npm run lint:fix` to fix all auto-fixable errors in source code and auto-format with prettier
- Ensure you fix any linting errors displayed after running any of the above commands

**What does this PR do?**

Add tests for upvoting and downvoting comments endpoint


**How should this be manually tested?**

running `npm test` should display the written test

**Any background context you want to provide?**

I will like to return to this test when getting a comment is implemented. I'm only testing that the returned value satisfy the spec. I will like to get the comment and verify that the vote is incremented or decremented accordingly

**What is the link to the issue on Github?**

[Issue #75](https://github.com/microapidev/comment-microapi/issues/75)

**Questions:**

most of the endpoints seems to not have been implemented