### PR TITLE
feat: add get endpoint for a reply

### DIFF
--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -1426,6 +1426,65 @@ paths:
 
   # Endpoint to update a reply of a comment
   /comments/{commentId}/replies/{replyId}:
+    # GET operation
+    get:
+      tags:
+        - comments
+
+      summary: Gets a reply of a comment
+
+      security:
+        - Bearer: []
+
+      parameters:
+        - in: path
+          $ref: "#/components/parameters/commentIdParam"
+
+        - in: path
+          $ref: "#/components/parameters/replyIdParam"
+
+      responses:
+        "200":
+          description: Successful operation
+          content:
+            application/json:
+              schema:
+                type: object
+                required:
+                  - message
+                  - response
+                  - data
+                properties:
+                  message:
+                    type: string
+                  response:
+                    type: string
+                  data:
+                    type: array
+                    items:
+                      $ref: "#/components/schemas/Reply"
+
+        "400":
+          description: Bad request error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+
+        "401":
+          description: Authentication error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+
+        "404":
+          description: Invalid ID error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+
     # PATCH operation
     patch:
       tags:


### PR DESCRIPTION
**Before submitting your PR for review**

- Run `npm run lint` to find errors in code syntax/format
- Run `npm run lint:fix` to fix all auto-fixable errors in source code and auto-format with prettier
- Ensure you fix any linting errors displayed after running any of the above commands

**What does this PR do?**
Adds the missing `GET /comments/{commentId}/replies/{replyId}` endpoint to the swagger docs.

**description of Task to be completed?**
Update the swagger.yaml file to include the missing endpoint.

**How should this be manually tested?**
- On you terminal, run `npm start`
- Visit `localhost:4000` or `localhost:4000/documentation`

**Any background context you want to provide?**
None

**What is the link to the issue on Github?**

[Issue #90](https://github.com/microapidev/comment-microapi/issues/90)

**Questions:**

None