### PR TITLE
CommentsEndpointTests - PATCH /comments/{commentId}/votes/*: Refactor comment upvote and downvote test suite to match new spec

### DIFF
--- a/__test__/api/comment-vote.test.js
+++ b/__test__/api/comment-vote.test.js
@@ -7,71 +7,64 @@ import { describeIfEndpoint } from "../helpers/conditionalTests";
 
 describeIfEndpoint(
   "PATCH",
-  "/comments/:commentId/votes",
-  "PATCH '/comments/:commentId/votes'",
+  "/comments/:commentId/votes/upvote",
+  "PATCH '/comments/:commentId/votes/upvote'",
   () => {
     test("Should upvote a comment", async () => {
-      const comment = new CommentModel({
+      const commentObject = {
         content: "this is a comment",
         ownerId: "useremail@email.com",
         origin: "123123",
         applicationId: mongoose.Types.ObjectId(),
-      });
+      };
+      const comment = new CommentModel(commentObject);
       await comment.save();
 
-      const res = await request.patch(`/comments/${comment._id}/votes`).send({
-        voteType: "upvote",
-      });
+      const res = await request
+        .patch(`/comments/${comment._id}/votes/upvote`)
+        .send({
+          ownerId: commentObject.ownerId,
+        });
       if (res.status === 404) {
         return true; // route not implemented yet
       }
       expect(res.status).toBe(200);
-      expect(res.body.data.commentId).toBeTruthy();
-      expect(res.body.data.totalVotes).toBeTruthy();
-      expect(res.body.data.upvotes).toBeTruthy();
-      expect(res.body.data.downvotes).toBeTruthy();
+      expect(res.body.data.commentId).toEqual(comment._id);
+      expect(res.body.data.numOfVotes).toEqual(1);
+      expect(res.body.data.numOfUpVotes).toEqual(1);
+      expect(res.body.data.numOfDownVotes).toEqual(0);
     });
+  }
+);
 
+describeIfEndpoint(
+  "PATCH",
+  "/comments/:commentId/votes/downvote",
+  "PATCH '/comments/:commentId/votes/downvote'",
+  () => {
     test("Should downvote a comment", async () => {
-      const comment = new CommentModel({
+      const commentObject = {
         content: "this is a comment",
         ownerId: "useremail2@email.com",
         origin: "123123",
         applicationId: mongoose.Types.ObjectId(),
-      });
+      };
+      const comment = new CommentModel(commentObject);
       await comment.save();
 
-      const res = await request.patch(`/comments/${comment._id}/votes`).send({
-        voteType: "downvote",
-      });
+      const res = await request
+        .patch(`/comments/${comment._id}/votes/downvote`)
+        .send({
+          ownerId: commentObject.ownerId,
+        });
       if (res.status === 404) {
         return true; // route not implemented yet
       }
       expect(res.status).toBe(200);
-      expect(res.body.data.commentId).toBeTruthy();
-      expect(res.body.data.totalVotes).toBeTruthy();
-      expect(res.body.data.upvotes).toBeTruthy();
-      expect(res.body.data.downvotes).toBeTruthy();
-    });
-
-    test("Should reject unknown vote type", async () => {
-      const comment = new CommentModel({
-        content: "this is a comment",
-        ownerId: "useremail3@email.com",
-        origin: "123123",
-        applicationId: mongoose.Types.ObjectId(),
-      });
-      await comment.save();
-
-      const res = await request.patch(`/comments/${comment._id}/votes`).send({
-        voteType: "invalid",
-      });
-      if (res.status === 404) {
-        return true; // route not implemented yet
-      }
-      expect(res.status).toBe(422);
-      expect(res.body.data.status).toBeTruthy();
-      expect(res.body.data.message).toBeTruthy();
+      expect(res.body.data.commentId).toEqual(comment._id);
+      expect(res.body.data.numOfVotes).toEqual(1);
+      expect(res.body.data.numOfUpVotes).toEqual(0);
+      expect(res.body.data.numOfDownVotes).toEqual(1);
     });
   }
 );

--- a/__test__/api/comment-vote.test.js
+++ b/__test__/api/comment-vote.test.js
@@ -25,9 +25,6 @@ describeIfEndpoint(
         .send({
           ownerId: commentObject.ownerId,
         });
-      if (res.status === 404) {
-        return true; // route not implemented yet
-      }
       expect(res.status).toBe(200);
       expect(res.body.data.commentId).toEqual(String(comment._id));
       expect(res.body.data.numOfVotes).toEqual(1);
@@ -57,9 +54,6 @@ describeIfEndpoint(
         .send({
           ownerId: commentObject.ownerId,
         });
-      if (res.status === 404) {
-        return true; // route not implemented yet
-      }
       expect(res.status).toBe(200);
       expect(res.body.data.commentId).toEqual(String(comment._id));
       expect(res.body.data.numOfVotes).toEqual(1);

--- a/__test__/api/comment-vote.test.js
+++ b/__test__/api/comment-vote.test.js
@@ -29,7 +29,7 @@ describeIfEndpoint(
         return true; // route not implemented yet
       }
       expect(res.status).toBe(200);
-      expect(res.body.data.commentId).toEqual(comment._id);
+      expect(res.body.data.commentId).toEqual(String(comment._id));
       expect(res.body.data.numOfVotes).toEqual(1);
       expect(res.body.data.numOfUpVotes).toEqual(1);
       expect(res.body.data.numOfDownVotes).toEqual(0);
@@ -61,7 +61,7 @@ describeIfEndpoint(
         return true; // route not implemented yet
       }
       expect(res.status).toBe(200);
-      expect(res.body.data.commentId).toEqual(comment._id);
+      expect(res.body.data.commentId).toEqual(String(comment._id));
       expect(res.body.data.numOfVotes).toEqual(1);
       expect(res.body.data.numOfUpVotes).toEqual(0);
       expect(res.body.data.numOfDownVotes).toEqual(1);


### PR DESCRIPTION
**What does this PR do?**
Continues PR #98  Issue #75 

Summarise the main tasks handled in the pull request

* Match specification
* Ensure the number of votes returned is correct

Describe (in detail) what the task completed in the pull request does as per the relevant task
* Inserts a comment into the database, and visit the upvote route, then check that the total number of votes and the total number of upvotes are both equal to 1 and total number of downvote is 0
* Inserts a comment into the database and visit the downvote route, then check that the number of votes returned is as expected

**Any background context you want to provide?**
I had already written the tests when upvote and downvote were separate routes. 

Any pertinent information that should be considered

**What is the link to the issue on Github?**

[Issue #75](https://github.com/microapidev/comment-microapi/issues/75)