### PR TITLE
 RepliesController - DELETE /comments/{commentId}/replies/{replyId}

### DIFF
--- a/__test__/api/comment-delete.test.js
+++ b/__test__/api/comment-delete.test.js
@@ -48,25 +48,24 @@ describeIfEndpoint(
       await comment.save();
 
       const reply = new ReplyModel({
-        replyBody: "this is a reply to a comment",
+        content: "this is a reply to a comment",
         commentId: comment._id,
         upVotes: 0,
         downVotes: 0,
+        ownerId: "useremail@email.com",
       });
       await reply.save();
 
       const res = await request
         .delete(`/comments/${comment._id}/replies/${reply._id}`)
         .send({
-          replyOwnerEmail: "useremail@email.com",
+          ownerId: "useremail@email.com",
         });
-      if (res.status === 404) {
-        return true; // route not implemented yet
-      }
+
       expect(res.status).toBe(200);
-      expect(res.body.data.replyId).toEqual(reply._id);
-      expect(res.body.data.commentId).toEqual(comment._id);
-      expect(res.body.data.replyOwnerEmail).toBeTruthy();
+      expect(res.body.data.replyId).toEqual(String(reply._id));
+      expect(res.body.data.commentId).toEqual(String(comment._id));
+      expect(res.body.data.ownerId).toBeTruthy();
     });
   }
 );

--- a/controller/repliesController.js
+++ b/controller/repliesController.js
@@ -268,10 +268,47 @@ const flagCommentReplies = async (req, res, next) => {
   }
 };
 
+const deleteCommentReply = async (req, res, next) => {
+  const { commentId, replyId } = req.params;
+  const { ownerId } = req.body;
+  if (!ObjectId.isValid(commentId))
+    return next(new CustomError(422, "invalid comment id"));
+  if (!ObjectId.isValid(replyId))
+    return next(new CustomError(422, "invalid reply id"));
+
+  try {
+    const reply = await Replies.findOneAndDelete({
+      ownerId,
+      commentId,
+      _id: replyId,
+    });
+    if (!reply) {
+      return next(new CustomError(404, "reply not found"));
+    }
+    await Comments.findByIdAndUpdate(commentId, {
+      // it doesn't matter if the parent exist or not
+      $pull: { replies: replyId },
+    });
+
+    const { _id: dbReplyId, ...rest } = reply.toObject();
+
+    return responseHandler(
+      res,
+      200,
+      { replyId: dbReplyId, ...rest },
+      "Reply successfully deleted"
+    );
+  } catch (err) {
+    return next(
+      new CustomError(500, "Something went wrong, please try again later", err)
+    );
+  }
+};
 module.exports = {
   getCommentReplies,
   getASingleReply,
   createReply,
   getReplyVotes,
   flagCommentReplies,
+  deleteCommentReply,
 };

--- a/routes/replies.js
+++ b/routes/replies.js
@@ -16,4 +16,7 @@ router.get("/:replyId/votes", repliesController.getReplyVotes);
 /// updates the flags of a reply
 router.patch("/:replyId/flag", repliesController.flagCommentReplies);
 
+// delete a reply
+router.delete("/:replyId", repliesController.deleteCommentReply);
+
 module.exports = router;


### PR DESCRIPTION
**What does this PR do?**

Fixes #126 
Summarise the main tasks handled in the pull request

* Write the controller for deleting replies
* Add the route
* Fix the test

Describe (in detail) what the task completed in the pull request does as per the relevant task

Delete the reply matching the `replyId`, `commentId`, and `ownerId` from the database, remove the reply from the list of replies for the comment. Return the deleted reply.

**How should this be manually tested?**
Run `npm test -- -t "DELETE /comments/:commentId/replies/:replyId"` to see the test for the route pass

**What is the link to the issue on Github?**

[Issue #126 ](https://github.com/microapidev/comment-microapi/issues/126)
