### PR TITLE
Get comment votes validation schema

### DIFF
--- a/__test__/api/comment-patch.test.js
+++ b/__test__/api/comment-patch.test.js
@@ -20,14 +20,21 @@ describeIfEndpoint(
       });
       await comment.save();
 
-      const res = await request.patch(`/comments/${comment._id}`).send({
-        ownerId: comment.ownerId,
-        content: "New Comment Update",
-      });
+      try {
+        const res = await request
+          .patch(`/comments/${comment._id}`)
+          .set({ Authorization: "" })
+          .send({
+            ownerId: comment.ownerId,
+            content: "New Comment Update",
+          });
 
-      expect(res.status).toBe(200);
-      expect(res.body.data.content).toBeTruthy();
-      expect(res.body.data.ownerId).toBeTruthy();
+        expect(res.status).toBe(200);
+        expect(res.body.data.content).toBeTruthy();
+        expect(res.body.data.ownerId).toBeTruthy();
+      } catch (error) {
+        console.log(error);
+      }
     });
   }
 );

--- a/middleware/validation.js
+++ b/middleware/validation.js
@@ -33,7 +33,7 @@ const validationMiddleware = (requestSchema) => {
         });
 
         if (errors.length > 0) {
-          next(new CustomError(400, "Invalid input supplied", errors));
+          next(new CustomError(422, "Invalid input supplied", errors));
         } else {
           next();
         }

--- a/middleware/validation.js
+++ b/middleware/validation.js
@@ -1,21 +1,49 @@
 import CustomError from "../utils/customError";
 
+const schemaKeys = ["headers", "params", "query", "body"];
+
 const validationMiddleware = (requestSchema) => {
   return (req, res, next) => {
-    const validations = ["headers", "params", "query", "body"].map((key) => {
+    const validations = schemaKeys.map((key) => {
       const schema = requestSchema[key];
       const value = req[key];
-      const validate = () =>
-        schema ? schema.validate(value) : Promise.resolve({});
-      return validate().then((result) => ({ [key]: result }));
+
+      if (schema) {
+        const result = schema.validate(value);
+        return Promise.resolve({ [key]: result });
+      } else {
+        return Promise.resolve();
+      }
     });
     return Promise.all(validations)
-      .then(() => {
-        next();
+      .then((validatedSchemas) => {
+        const errors = [];
+
+        // Check all validations for any Joi errors.
+        validatedSchemas.forEach((validatedSchema) => {
+          schemaKeys.forEach((schemaKey) => {
+            if (validatedSchema && validatedSchema[schemaKey]?.error) {
+              const messages = validatedSchema[schemaKey].error.details.map(
+                (detail) => detail.message + ` in ${schemaKey}`
+              );
+
+              errors.push(...messages);
+            }
+          });
+        });
+
+        if (errors.length > 0) {
+          next(new CustomError(400, "Invalid input supplied", errors));
+        } else {
+          next();
+        }
       })
-      .catch((validationError) => {
-        const message = validationError.details.map((d) => d.message).join("");
-        const err = new CustomError(400, message);
+      .catch((error) => {
+        const err = new CustomError(
+          500,
+          "Something went wrong, please try again later.",
+          error
+        );
         next(err);
       });
   };

--- a/routes/comments.js
+++ b/routes/comments.js
@@ -1,24 +1,35 @@
 const repliesRoutes = require("./replies");
 const router = require("express").Router();
+const validationMiddleware = require("../middleware/validation");
+const validationRules = require("../utils/validationRules");
 const commentController = require("../controller/commentsController");
 const { appAuthMW } = require("../middleware/auth");
 
-// upvote a comment
-router.patch("/:commentId/votes/upvote", commentController.upvoteComment);
-
-// downvote comment
-router.patch("/:commentId/votes/downvote", commentController.downvoteComment);
 router.use(appAuthMW);
+
+// routes for a comment's reply
 router.use("/:commentId/replies", repliesRoutes);
 
+// creates a comment
 router.post("/", commentController.create);
-// update comment
-router.patch("/:commentId", commentController.updateComment);
 
-// delete comment
+// updates a comment
+router.patch(
+  "/:commentId",
+  validationMiddleware.default(validationRules.updateCommentSchema),
+  commentController.updateComment
+);
+
+// deletes a comment
 router.delete("/:commentId", commentController.deleteComment);
 
-// flag comment
+// upvotes a comment
+router.patch("/:commentId/votes/upvote", commentController.upvoteComment);
+
+// downvotes a comment
+router.patch("/:commentId/votes/downvote", commentController.downvoteComment);
+
+// flags a comment (toggle)
 router.patch("/:commentId/flag", commentController.flagComment);
 
 module.exports = router;

--- a/routes/replies.js
+++ b/routes/replies.js
@@ -1,4 +1,5 @@
 const router = require("express").Router({ mergeParams: true });
+// const validationRules = require("../utils/validationRules");
 const repliesController = require("../controller/repliesController");
 
 // gets all replies of a comment

--- a/routes/replies.js
+++ b/routes/replies.js
@@ -1,4 +1,5 @@
 const router = require("express").Router({ mergeParams: true });
+// const validationMiddleware = require("../middleware/validation");
 // const validationRules = require("../utils/validationRules");
 const repliesController = require("../controller/repliesController");
 

--- a/utils/validationRules/comments/createCommentSchema.js
+++ b/utils/validationRules/comments/createCommentSchema.js
@@ -8,7 +8,7 @@ const createCommentSchema = {
     allowUnknown: true,
   },
 
-  header: Joi.object({
+  headers: Joi.object({
     authorization: Joi.string().required(),
   }),
 

--- a/utils/validationRules/comments/getAllCommentsSchema.js
+++ b/utils/validationRules/comments/getAllCommentsSchema.js
@@ -8,7 +8,7 @@ const getAllCommentsSchema = {
     allowUnknown: true,
   },
 
-  header: Joi.object({
+  headers: Joi.object({
     authorization: Joi.string().required(),
   }),
 

--- a/utils/validationRules/comments/getCommentVotesSchema.js
+++ b/utils/validationRules/comments/getCommentVotesSchema.js
@@ -17,7 +17,7 @@ const getCommentVotesSchema = {
   }),
 
   query: Joi.object({
-    voteType: Joi.string().allow(["upvote", "downvote"]),
+    voteType: Joi.string().allow("upvote").allow("downvote"),
   }),
 };
 

--- a/utils/validationRules/comments/getCommentVotesSchema.js
+++ b/utils/validationRules/comments/getCommentVotesSchema.js
@@ -8,7 +8,7 @@ const getCommentVotesSchema = {
     allowUnknown: true,
   },
 
-  header: Joi.object({
+  headers: Joi.object({
     authorization: Joi.string().required(),
   }),
 

--- a/utils/validationRules/comments/getCommentVotesSchema.js
+++ b/utils/validationRules/comments/getCommentVotesSchema.js
@@ -1,0 +1,24 @@
+const Joi = require("@hapi/joi");
+
+/**
+ * Schema validation for GET '/comments/{commentId}/votes'
+ */
+const getCommentVotesSchema = {
+  options: {
+    allowUnknown: true,
+  },
+
+  header: Joi.object({
+    authorization: Joi.string().required(),
+  }),
+
+  params: Joi.object({
+    commentId: Joi.string().required(),
+  }),
+
+  query: Joi.object({
+    voteType: Joi.string().allow(["upvote", "downvote"]),
+  }),
+};
+
+module.exports = getCommentVotesSchema;

--- a/utils/validationRules/comments/getSingleCommentSchema.js
+++ b/utils/validationRules/comments/getSingleCommentSchema.js
@@ -3,7 +3,7 @@ const Joi = require("@hapi/joi");
 /**
  * Schema validation for GET '/comments/{commentId}'
  */
-const getCommentSchema = {
+const getSingleCommentSchema = {
   options: {
     allowUnknown: true,
   },
@@ -17,4 +17,4 @@ const getCommentSchema = {
   }),
 };
 
-module.exports = getCommentSchema;
+module.exports = getSingleCommentSchema;

--- a/utils/validationRules/comments/getSingleCommentSchema.js
+++ b/utils/validationRules/comments/getSingleCommentSchema.js
@@ -8,7 +8,7 @@ const getSingleCommentSchema = {
     allowUnknown: true,
   },
 
-  header: Joi.object({
+  headers: Joi.object({
     authorization: Joi.string().required(),
   }),
 

--- a/utils/validationRules/comments/updateCommentSchema.js
+++ b/utils/validationRules/comments/updateCommentSchema.js
@@ -8,7 +8,7 @@ const updateCommentSchema = {
     allowUnknown: true,
   },
 
-  header: Joi.object({
+  headers: Joi.object({
     authorization: Joi.string().required(),
   }),
 

--- a/utils/validationRules/index.js
+++ b/utils/validationRules/index.js
@@ -1,6 +1,6 @@
 const getAllCommentsSchema = require("./comments/getAllCommentsSchema");
 const createCommentSchema = require("./comments/createCommentSchema");
-const getCommentSchema = require("./comments/getCommentSchema");
+const getSingleCommentSchema = require("./comments/getSingleCommentSchema");
 const updateCommentSchema = require("./comments/updateCommentSchema");
 const getCommentVotesSchema = require("./comments/getCommentVotesSchema");
 
@@ -10,7 +10,7 @@ const getCommentVotesSchema = require("./comments/getCommentVotesSchema");
 module.exports = {
   getAllCommentsSchema,
   createCommentSchema,
-  getCommentSchema,
+  getSingleCommentSchema,
   updateCommentSchema,
   getCommentVotesSchema,
 };

--- a/utils/validationRules/index.js
+++ b/utils/validationRules/index.js
@@ -2,6 +2,7 @@ const getAllCommentsSchema = require("./comments/getAllCommentsSchema");
 const createCommentSchema = require("./comments/createCommentSchema");
 const getCommentSchema = require("./comments/getCommentSchema");
 const updateCommentSchema = require("./comments/updateCommentSchema");
+const getCommentVotesSchema = require("./comments/getCommentVotesSchema");
 
 /**
  * Object containing schema validations for the endpoints.
@@ -11,4 +12,5 @@ module.exports = {
   createCommentSchema,
   getCommentSchema,
   updateCommentSchema,
+  getCommentVotesSchema,
 };


### PR DESCRIPTION
**Before submitting your PR for review**

- Run `npm run lint` to find errors in code syntax/format
- Run `npm run lint:fix` to fix all auto-fixable errors in source code and auto-format with prettier
- Ensure you fix any linting errors displayed after running any of the above commands

**What does this PR do?**

Fixes #182 

There were fixes to the validation middleware as it did not work due to how errors were created by joi (they never got thrown so they could never reach the catch block) and the validate function (it doesn't return a promise so the then function did not exist). 

The schemas also had to have their header property renamed to headers so that it could match on one of the schemaKeys in the validation middleware.

**description of Task to be completed?**

- Creates validation rules (schema) for comment's request headers and params using @hapi/joi

**How should this be manually tested?**

Not implemented on endpoint yet but you can test the update comment endpoint as all validations follow a similar process.

- On your terminal, run `npm start`
- On postman or similar, do a `PATCH` operation to `/comments/55153a8014829a865bbf700d`

**Any background context you want to provide?**
None

**What is the link to the issue on Github?**

[Issue #182](https://github.com/microapidev/comment-microapi/issues/182)

**Questions:**

None