### PR TITLE
feat: add validation schema for updating comment votes

### DIFF
--- a/utils/validationRules/comments/updateCommentUpAndDownVoteSchema.js
+++ b/utils/validationRules/comments/updateCommentUpAndDownVoteSchema.js
@@ -1,0 +1,24 @@
+const Joi = require("@hapi/joi");
+
+/**
+ * Schema validation for PATCH '/comments/{commentId}/votes/upvote'
+ */
+const updateCommentUpAndDownVoteSchema = {
+  options: {
+    allowUnknown: true,
+  },
+
+  header: Joi.object({
+    authorization: Joi.string().required(),
+  }),
+
+  params: Joi.object({
+    commentId: Joi.string().required(),
+  }),
+
+  body: Joi.object().keys({
+    ownerId: Joi.string().required(),
+  }),
+};
+
+module.exports = updateCommentUpAndDownVoteSchema;

--- a/utils/validationRules/index.js
+++ b/utils/validationRules/index.js
@@ -4,6 +4,7 @@ const getSingleCommentSchema = require("./comments/getSingleCommentSchema");
 const updateCommentSchema = require("./comments/updateCommentSchema");
 const deleteCommentSchema = require("./comments/deleteCommentSchema");
 const getCommentVotesSchema = require("./comments/getCommentVotesSchema");
+const updateCommentUpAndDownVoteSchema = require("./comments/updateCommentUpAndDownVoteSchema");
 
 /**
  * Object containing schema validations for the endpoints.
@@ -15,4 +16,5 @@ module.exports = {
   updateCommentSchema,
   deleteCommentSchema,
   getCommentVotesSchema,
+  updateCommentUpAndDownVoteSchema,
 };


### PR DESCRIPTION
**Before submitting your PR for review**

- Run `npm run lint` to find errors in code syntax/format
- Run `npm run lint:fix` to fix all auto-fixable errors in source code and auto-format with prettier
- Ensure you fix any linting errors displayed after running any of the above commands

**What does this PR do?**

Fixes #200 

The PR implements for 2 endpoints as they have the same validation schema.

Summarise the main tasks handled in the pull request

**description of Task to be completed?**

- Add validation schema for updating upvotes
- Use the same validation schema for downvotes

**How should this be manually tested?**

Endpoints need to implement validation middleware first.

**Any background context you want to provide?**

None

**What is the link to the issue on Github?**

[Issue #200](https://github.com/microapidev/comment-microapi/issues/200)

**Questions:**

None