### PR TITLE
feat: add validation schema for up and down vote endpoint

### DIFF
--- a/utils/validationRules/Replies/updateReplyUpAndDownVoteSchema.js
+++ b/utils/validationRules/Replies/updateReplyUpAndDownVoteSchema.js
@@ -1,0 +1,25 @@
+const Joi = require("@hapi/joi");
+
+/**
+ * Schema validation for PATCH '/comments/{commentId}/replies/{replyId}/votes/upvote'
+ */
+const updateReplyUpAndDownVoteSchema = {
+  options: {
+    allowUnknown: true,
+  },
+
+  header: Joi.object({
+    authorization: Joi.string().required(),
+  }),
+
+  params: Joi.object({
+    commentId: Joi.string().required(),
+    replyId: Joi.string().required(),
+  }),
+
+  body: Joi.object().keys({
+    ownerId: Joi.string().required(),
+  }),
+};
+
+module.exports = updateReplyUpAndDownVoteSchema;

--- a/utils/validationRules/index.js
+++ b/utils/validationRules/index.js
@@ -6,10 +6,13 @@ const deleteCommentSchema = require("./comments/deleteCommentSchema");
 const getCommentVotesSchema = require("./comments/getCommentVotesSchema");
 const updateCommentUpAndDownVoteSchema = require("./comments/updateCommentUpAndDownVoteSchema");
 
+const updateReplyUpAndDownVoteSchema = require("./Replies/updateReplyUpAndDownVoteSchema");
+
 /**
  * Object containing schema validations for the endpoints.
  */
 module.exports = {
+  // Comment endpoints validation schemas
   getAllCommentsSchema,
   createCommentSchema,
   getSingleCommentSchema,
@@ -17,4 +20,7 @@ module.exports = {
   deleteCommentSchema,
   getCommentVotesSchema,
   updateCommentUpAndDownVoteSchema,
+
+  // Reply Endpoints validation schemas
+  updateReplyUpAndDownVoteSchema,
 };


### PR DESCRIPTION
**Before submitting your PR for review**

- Run `npm run lint` to find errors in code syntax/format
- Run `npm run lint:fix` to fix all auto-fixable errors in source code and auto-format with prettier
- Ensure you fix any linting errors displayed after running any of the above commands

**What does this PR do?**

Fixes #203 

The PR implements for 2 endpoints as they have the same validation schema.

**description of Task to be completed?**

- Add validation schema for updating upvotes
- Use the same validation schema for downvotes**How should this be manually tested?**

Endpoints need to implement validation middleware first.

**Any background context you want to provide?**

None

**What is the link to the issue on Github?**

[Issue #203 ](https://github.com/microapidev/comment-microapi/issues/203)

**Questions:**

None