### PR TITLE
fix: change the import to use require instead

### DIFF
--- a/__test__/api/comment-patch.test.js
+++ b/__test__/api/comment-patch.test.js
@@ -20,21 +20,17 @@ describeIfEndpoint(
       });
       await comment.save();
 
-      try {
-        const res = await request
-          .patch(`/comments/${comment._id}`)
-          .set({ Authorization: "" })
-          .send({
-            ownerId: comment.ownerId,
-            content: "New Comment Update",
-          });
+      const res = await request
+        .patch(`/comments/${comment._id}`)
+        .set({ Authorization: "" })
+        .send({
+          ownerId: comment.ownerId,
+          content: "New Comment Update",
+        });
 
-        expect(res.status).toBe(200);
-        expect(res.body.data.content).toBeTruthy();
-        expect(res.body.data.ownerId).toBeTruthy();
-      } catch (error) {
-        console.log(error);
-      }
+      expect(res.status).toBe(200);
+      expect(res.body.data.content).toBeTruthy();
+      expect(res.body.data.ownerId).toBeTruthy();
     });
   }
 );

--- a/middleware/validation.js
+++ b/middleware/validation.js
@@ -1,4 +1,4 @@
-import CustomError from "../utils/customError";
+const CustomError = require("../utils/customError");
 
 const schemaKeys = ["headers", "params", "query", "body"];
 

--- a/middleware/validation.js
+++ b/middleware/validation.js
@@ -22,7 +22,11 @@ const validationMiddleware = (requestSchema) => {
         // Check all validations for any Joi errors.
         validatedSchemas.forEach((validatedSchema) => {
           schemaKeys.forEach((schemaKey) => {
-            if (validatedSchema && validatedSchema[schemaKey]?.error) {
+            if (
+              validatedSchema &&
+              validatedSchema[schemaKey] &&
+              validatedSchema[schemaKey].error
+            ) {
               const messages = validatedSchema[schemaKey].error.details.map(
                 (detail) => detail.message + ` in ${schemaKey}`
               );
@@ -49,4 +53,4 @@ const validationMiddleware = (requestSchema) => {
   };
 };
 
-export default validationMiddleware;
+module.exports = validationMiddleware;

--- a/routes/comments.js
+++ b/routes/comments.js
@@ -18,7 +18,7 @@ router.post("/", commentController.create);
 // updates a comment
 router.patch(
   "/:commentId",
-  validationMiddleware.default(validationRules.updateCommentSchema),
+  validationMiddleware(validationRules.updateCommentSchema),
   commentController.updateComment
 );
 


### PR DESCRIPTION
**Before submitting your PR for review**

- Run `npm run lint` to find errors in code syntax/format
- Run `npm run lint:fix` to fix all auto-fixable errors in source code and auto-format with prettier
- Ensure you fix any linting errors displayed after running any of the above commands

**What does this PR do?**
It is a hotfix for the current Application Error on the heroku servers due to integration with ES6 modules not working. The fix changes imports in validation.js middleware to require. 

**description of Task to be completed?**

- Change import to require instead

**How should this be manually tested?**

None

**Any background context you want to provide?**

None

**What is the link to the issue on Github?**

None

**Questions:**

None