### PR TITLE
Update eslint config to suppress eol errors

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -9,5 +9,12 @@ module.exports = {
     ecmaVersion: 11,
     sourceType: "module",
   },
-  rules: {},
+  rules: {
+    "prettier/prettier": [
+      "error",
+      {
+        endOfLine: "auto",
+      },
+    ],
+  },
 };


### PR DESCRIPTION
**Before submitting your PR for review**

- [x] Run `npm run lint` to find errors in code syntax/format
- [x] Run `npm run lint:fix` to fix all auto-fixable errors in source code and auto-format with prettier
- [x] Ensure you fix any linting errors displayed after running any of the above commands

**What does this PR do?**

Add eslint rule to suppress end of line errors where eol is CRLF.

EOL defaults to LF for my device, not sure why. But this update sets EOL to auto which makes it use CRLF for Windows and LF for other devices.

**description of Task to be completed?**

Add rule

```javascript
    "prettier/prettier": [
      "error",
      {
        endOfLine: "auto",
      },
    ],
```

**How should this be manually tested?**

**Any background context you want to provide?**

**What is the link to the issue on Github?**

**Questions:**