### PR TITLE
[TEST] RepliesEndpointTests - PATCH /comments/{commentId}/replies/{replyId}/flag (#222)

### DIFF
--- a/__test__/api/comment-patch.test.js
+++ b/__test__/api/comment-patch.test.js
@@ -1,6 +1,6 @@
 const app = require("../../server");
 const CommentModel = require("../../models/comments");
-// const ReplyModel = require("../../models/replies");
+const ReplyModel = require("../../models/replies");
 const mongoose = require("mongoose");
 const supertest = require("supertest");
 const request = supertest(app);
@@ -56,6 +56,40 @@ describeIfEndpoint(
       expect(res.status).toBe(200);
       expect(res.body.data.commentId).toBeTruthy();
       expect(res.body.data.numOfFlags).toBeTruthy();
+    });
+  }
+);
+
+describeIfEndpoint(
+  "PATCH",
+  "/comments/:commentId/replies/:replyId/flag",
+  "PATCH /comments/:commentId/replies/:replyId/flag",
+  () => {
+    it("Flags a reply to a comment", async () => {
+      const comment = new CommentModel({
+        content: "this is a comment",
+        ownerId: "useremail@email.com",
+        origin: "123123",
+        applicationId: mongoose.Types.ObjectId(),
+      });
+      await comment.save();
+
+      const reply = new ReplyModel({
+        content: "this is a reply to a comment",
+        commentId: comment._id,
+        upVotes: 0,
+        downVotes: 0,
+        ownerId: "useremail@email.com",
+      });
+      await reply.save();
+
+      const res = await request.patch(`/comments/${comment._id}/replies/${reply._id}/flag`).send({
+        ownerId: "offendeduser@email.com",
+      });
+
+      expect(res.status).toBe(200);
+      expect(res.body.data.commentId).toBeTruthy();
+      expect(res.body.data.numOfFlags).toEqual(1);
     });
   }
 );

--- a/__test__/api/comment-patch.test.js
+++ b/__test__/api/comment-patch.test.js
@@ -83,9 +83,11 @@ describeIfEndpoint(
       });
       await reply.save();
 
-      const res = await request.patch(`/comments/${comment._id}/replies/${reply._id}/flag`).send({
-        ownerId: "offendeduser@email.com",
-      });
+      const res = await request
+        .patch(`/comments/${comment._id}/replies/${reply._id}/flag`)
+        .send({
+          ownerId: "offendeduser@email.com",
+        });
 
       expect(res.status).toBe(200);
       expect(res.body.data.commentId).toBeTruthy();


### PR DESCRIPTION
**What does this PR do?**

Add tests for flagging the reply to a comment

Summarise the main tasks handled in the pull request

* save a test comment and a test reply
* then send a requst to the reply flagging route
* test that the returned number of flags is 1


[Issue #222 ](https://github.com/microapidev/comment-microapi/issues/222)