### PR TITLE
[hotfix]: fix bug in boolean environment variables

### DIFF
--- a/middleware/auth.js
+++ b/middleware/auth.js
@@ -1,16 +1,18 @@
 const jwtMW = require("express-jwt");
 require("dotenv").config();
 
+const credsRequired = process.env.DISABLE_AUTH.toLowerCase() === "false";
+
 exports.appAuthMW = jwtMW({
   secret: Buffer.from(process.env.APP_SECRET, "base64"),
   requestProperty: "token",
   algorithms: ["HS256"],
-  credentialsRequired: !process.env.DISABLE_AUTH,
+  credentialsRequired: credsRequired,
 });
 
 exports.orgAuthMW = jwtMW({
   secret: process.env.ORG_SECRET,
   requestProperty: "token",
   algorithms: ["HS256"],
-  credentialsRequired: !process.env.DISABLE_AUTH,
+  credentialsRequired: credsRequired,
 });


### PR DESCRIPTION
**Before submitting your PR for review**

- Run `npm run lint` to find errors in code syntax/format
- Run `npm run lint:fix` to fix all auto-fixable errors in source code and auto-format with prettier
- Ensure you fix any linting errors displayed after running any of the above commands

**What does this PR do?**

The `DISABLE_AUTH` environment variable is a boolean variable that is used to temporarily disable authentication in guarded routes. This is read in as string and the value needs to be cast to its true boolean value.

**description of Task to be completed?**
- Check string value of `DISABLE_AUTH` and convert it to its equivalent boolean value

**How should this be manually tested?**
- Toggling `DISABLE_AUTH` should no have the desired effects

**What is the link to the issue on Github?**

This is a quick bug fix