### PR TITLE
fix: return the correct format on endpoint to get all replies

### DIFF
--- a/controller/repliesController.js
+++ b/controller/repliesController.js
@@ -29,7 +29,21 @@ const getCommentReplies = async (req, res, next) => {
     if (!replies.length) {
       message = " No replies found. ";
     }
-    return responseHandler(res, 200, replies, message);
+
+    const data = replies.map((reply) => {
+      return {
+        replyId: reply._id,
+        commentId: reply.commentId,
+        ownerId: reply.ownerId,
+        content: reply.content,
+        numOfVotes: reply.upVotes.length + reply.downVotes.length,
+        numOfUpVotes: reply.upVotes.length,
+        numOfDownVotes: reply.downVotes.length,
+        numOfFlags: reply.flags.length,
+      };
+    });
+
+    return responseHandler(res, 200, data, message);
   } catch (err) {
     next(err);
   }


### PR DESCRIPTION
**Before submitting your PR for review**

- Run `npm run lint` to find errors in code syntax/format
- Run `npm run lint:fix` to fix all auto-fixable errors in source code and auto-format with prettier
- Ensure you fix any linting errors displayed after running any of the above commands

**What does this PR do?**

The current implementation for returning replies is returning a response body not in line with docs. Update the data format of the response in the controller method to get all replies.

**description of Task to be completed?**

- Update the data format of the response in the controller method to get all replies.

**How should this be manually tested?**

- In your terminal, run `npm start`
- Using postman or similar, make a GET `http://localhost:4000/v1/comments/5efb3451ed62e216f8c0a5a1/replies`

**Any background context you want to provide?**

None

**What is the link to the issue on Github?**

None

**Questions:**

None