### PR TITLE
fix: update response format on endpoint to get a reply

### DIFF
--- a/__test__/api/comment-get.test.js
+++ b/__test__/api/comment-get.test.js
@@ -109,10 +109,14 @@ describeIfEndpoint(
         .set("Authorization", `bearer ${global.appToken}`);
 
       expect(res.status).toBe(200);
-      expect(res.body.data._id).toEqual(String(replyId));
+      expect(res.body.data.replyId).toEqual(String(replyId));
       expect(res.body.data.commentId).toEqual(String(comment._id));
-      expect(res.body.data.content).toEqual(String(reply.content));
       expect(res.body.data.ownerId).toEqual(String(reply.ownerId));
+      expect(res.body.data.content).toEqual(String(reply.content));
+      expect(res.body.data.numOfVotes).toEqual(0);
+      expect(res.body.data.numOfUpVotes).toEqual(0);
+      expect(res.body.data.numOfDownVotes).toEqual(0);
+      expect(res.body.data.numOfFlags).toEqual(0);
     });
   }
 );

--- a/controller/repliesController.js
+++ b/controller/repliesController.js
@@ -72,7 +72,19 @@ const getASingleReply = async (req, res, next) => {
     if (!reply) {
       return next(new CustomError(404, " Reply not found "));
     }
-    return responseHandler(res, 200, reply, " Reply found ");
+
+    const data = {
+      replyId: reply._id,
+      commentId: reply.commentId,
+      ownerId: reply.ownerId,
+      content: reply.content,
+      numOfVotes: reply.upVotes.length + reply.downVotes.length,
+      numOfUpVotes: reply.upVotes.length,
+      numOfDownVotes: reply.downVotes.length,
+      numOfFlags: reply.flags.length,
+    };
+
+    return responseHandler(res, 200, data, " Reply found ");
   } catch (err) {
     next(
       new CustomError(500, " Something went wrong, please try again later,err")


### PR DESCRIPTION
**Before submitting your PR for review**

- Run `npm run lint` to find errors in code syntax/format
- Run `npm run lint:fix` to fix all auto-fixable errors in source code and auto-format with prettier
- Ensure you fix any linting errors displayed after running any of the above commands

**What does this PR do?**

The current implementation is returning the wrong format when getting a single reply. An update the format on the controller method ensures that the method returns a format in line with the docs.

**description of Task to be completed?**

- Update the format on the controller method for getting a single reply to be in line with the documentation

**How should this be manually tested?**

- In your terminal, run `npm start`
- On postman or similar, make a GET `http://localhost:4000/v1/comments/5efb3451ed62e216f8c0a5a1/replies/5eff06f0fa2a9a0017469f52`

**Any background context you want to provide?**

None

**What is the link to the issue on Github?**

None

**Questions:**

None