### PR TITLE
[FIX] Update the votes validation schema and controller methods for comments and replies votes' GET requests.

### DIFF
--- a/controller/commentsController.js
+++ b/controller/commentsController.js
@@ -375,16 +375,16 @@ exports.getCommentVotes = async (req, res, next) => {
     // votes array to store totalVotes, and also store upvotes or downvotes
     const votes = [];
 
-    if (voteType !== "upvote" && voteType !== "downvote") {
+    if (!voteType) {
       // Insert both upvotes and downvotes
       votes.push(...comment.upVotes);
       votes.push(...comment.downVotes);
     } else {
       // Insert upvotes only
-      if (voteType === "upvote") {
+      if (voteType.toString() === "upvote") {
         votes.push(...comment.upVotes);
       }
-      if (voteType === "downvote") {
+      if (voteType.toString() === "downvote") {
         // Insert downvotes only
         votes.push(...comment.downVotes);
       }

--- a/controller/repliesController.js
+++ b/controller/repliesController.js
@@ -301,12 +301,12 @@ const getReplyVotes = async (req, res, next) => {
       votes.push(...reply.upVotes);
       votes.push(...reply.downVotes);
     } else {
-      if (voteType === "upvote") {
+      if (voteType.toString() === "upvote") {
         // Add upvotes only
         votes.push(...reply.upVotes);
       }
 
-      if (voteType === "downvote") {
+      if (voteType.toString() === "downvote") {
         // Add downvotes only
         votes.push(...reply.downVotes);
       }

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -2444,6 +2444,9 @@ components:
       description: Filters comments, or replies, by vote type. If omitted, the response includes all comments, or replies, regardless of their vote type.
       schema:
         type: string
+        enum:
+          - upvote
+          - downvote
 
     refIdParam: # Can be referenced via '#/components/parameters/refIdParam'
       in: query

--- a/utils/validationRules/Replies/createReplySchema.js
+++ b/utils/validationRules/Replies/createReplySchema.js
@@ -9,7 +9,7 @@ const createReplySchema = {
   }),
 
   params: Joi.object({
-    commentId: Joi.string().length(24).required(),
+    commentId: Joi.string().required(),
   }),
 
   body: Joi.object().keys({

--- a/utils/validationRules/Replies/deleteReplySchema.js
+++ b/utils/validationRules/Replies/deleteReplySchema.js
@@ -9,8 +9,8 @@ const deleteReplySchema = {
   }),
 
   params: Joi.object().keys({
-    commentId: Joi.string().length(24).required(),
-    replyId: Joi.string().length(24).required(),
+    commentId: Joi.string().required(),
+    replyId: Joi.string().required(),
   }),
 
   body: Joi.object().keys({

--- a/utils/validationRules/Replies/getReplyVotesSchema.js
+++ b/utils/validationRules/Replies/getReplyVotesSchema.js
@@ -12,7 +12,7 @@ const getReplyVotesSchema = {
     replyId: Joi.string().required(),
   }),
   query: Joi.object().keys({
-    voteType: Joi.string(),
+    voteType: Joi.string().valid("upvote").valid("downvote"),
   }),
 };
 

--- a/utils/validationRules/Replies/getSingleReplySchema.js
+++ b/utils/validationRules/Replies/getSingleReplySchema.js
@@ -10,8 +10,8 @@ const getSingleReplySchema = {
   }),
 
   params: Joi.object().keys({
-    commentId: Joi.string().length(24).required(),
-    replyId: Joi.string().length(24).required(),
+    commentId: Joi.string().required(),
+    replyId: Joi.string().required(),
   }),
 };
 

--- a/utils/validationRules/comments/createCommentSchema.js
+++ b/utils/validationRules/comments/createCommentSchema.js
@@ -11,7 +11,7 @@ const createCommentSchema = {
   body: Joi.object().keys({
     refId: Joi.string(),
     ownerId: Joi.string().required(),
-    content: Joi.string().required(),
+    content: Joi.string().min(1).required(),
     origin: Joi.string(),
   }),
 };

--- a/utils/validationRules/comments/getCommentVotesSchema.js
+++ b/utils/validationRules/comments/getCommentVotesSchema.js
@@ -13,7 +13,7 @@ const getCommentVotesSchema = {
   }),
 
   query: Joi.object({
-    voteType: Joi.string().allow("upvote").allow("downvote"),
+    voteType: Joi.string().valid("upvote").valid("downvote"),
   }),
 };
 

--- a/utils/validationRules/comments/updateCommentSchema.js
+++ b/utils/validationRules/comments/updateCommentSchema.js
@@ -8,6 +8,10 @@ const updateCommentSchema = {
     authorization: Joi.string().required(),
   }),
 
+  params: Joi.object({
+    commentId: Joi.string().required(),
+  }),
+
   body: Joi.object().keys({
     content: Joi.string().min(1),
     ownerId: Joi.string().required(),


### PR DESCRIPTION
**Before submitting your PR for review**

- Run `npm run lint` to find errors in code syntax/format
- Run `npm run lint:fix` to fix all auto-fixable errors in source code and auto-format with prettier
- Ensure you fix any linting errors displayed after running any of the above commands

**What does this PR do?**

Fixes a few issues with the validation schema and controller methods. It also updates the docs to be more clear.

**description of Task to be completed?**

- Update the votes schemas to ensure that only `downvote` and `upvote` are accepted as valid.
- Update the votes controller methods to ensure that they can be compared with a string by first casting it to a string.
- Update the docs to only accept two options for voteType query parameter.

**How should this be manually tested?**

- In your terminal, run `npm start`.
- On your browser, visit `localhost:4000` for documentation.

**Any background context you want to provide?**

None

**What is the link to the issue on Github?**

None

**Questions:**

None