### PR TITLE
bug: fix swagger docs router

### DIFF
--- a/__test__/api/__snapshots__/index.test.js.snap
+++ b/__test__/api/__snapshots__/index.test.js.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`GET /v1 Should return status 200 and render Swagger docs 1`] = `
+exports[`GET / Should return status 200 and render Swagger docs 1`] = `
 "
 <!-- HTML for static distribution bundle build -->
 <!DOCTYPE html>

--- a/__test__/api/index.test.js
+++ b/__test__/api/index.test.js
@@ -1,9 +1,9 @@
 const app = require("../../server");
 const request = require("supertest");
 
-describe("GET /v1", () => {
+describe("GET /", () => {
   test("Should return status 200 and render Swagger docs", async () => {
-    const res = await request(app).get("/v1");
+    const res = await request(app).get("/");
     expect(res.status).toBe(200);
     expect(res.text).toMatchSnapshot();
   });

--- a/controllers/adminsController/changeAdminPassword.js
+++ b/controllers/adminsController/changeAdminPassword.js
@@ -10,7 +10,7 @@ const {
 /**
  * @author David Okanlawon
  *
- * Creates a single admin.
+ * Change admin password
  *
  * @param {*} req - The request object
  * @param {*} res - The response object

--- a/controllers/adminsController/getSingleAdmin.js
+++ b/controllers/adminsController/getSingleAdmin.js
@@ -6,7 +6,7 @@ const responseHandler = require("../../utils/responseHandler");
 /**
  * @author David Okanlawon
  *
- * Gets all admins.
+ * Gets single admin account.
  *
  * @param {*} req - The request object
  * @param {*} res - The response object

--- a/routes/documentation.js
+++ b/routes/documentation.js
@@ -5,8 +5,6 @@ const swaggerSpec = require("../utils/swaggerSpec");
 // use swagger-ui-express for your app documentation endpoint
 router.use("/", swaggerUi.serve);
 router.get("/", swaggerUi.setup(swaggerSpec));
-router.get("/v1", swaggerUi.setup(swaggerSpec));
 router.get("/documentation", swaggerUi.setup(swaggerSpec));
-router.get("/v1/documentation", swaggerUi.setup(swaggerSpec));
 
 module.exports = router;

--- a/server.js
+++ b/server.js
@@ -21,7 +21,7 @@ app.use("/v1/comments", commentRoutes);
 app.use("/v1/organizations", organizationsRoutes);
 app.use("/v1/applications", applicationsRoutes);
 app.use("/v1/admins", adminsRoutes);
-app.use(["/", "/v1", "/v1/documentation"], documentationRoutes);
+app.use(["/v1", "/"], documentationRoutes);
 
 // Invalid route error handler
 app.use("*", (req, res, next) => {


### PR DESCRIPTION
**Before submitting your PR for review**

- Run `npm run lint` to find errors in code syntax/format
- Run `npm run lint:fix` to fix all auto-fixable errors in source code and auto-format with prettier
- Ensure you fix any linting errors displayed after running any of the above commands

**What does this PR do?**

Fixes #315 

Swagger docs does not display on `/v1/documentation` route

**Description of Task to be completed?**

Fix routing to display swagger docs on `/`, `v1`, `/v1/documentation`

**How should this be manually tested?**

Visit `/v1/documentation` and other roues specified above should display swagger docs

**What is the link to the issue on Github?**

[Issue #315 ](https://github.com/microapidev/comment-microapi/issues/315)