### PR TITLE
[FIX] getAllReplies API Endpoint Test

### DIFF
--- a/__test__/api/comment-get.test.js
+++ b/__test__/api/comment-get.test.js
@@ -24,40 +24,6 @@ describeIfEndpoint("GET", "/v1/comments", "GET '/comments' ", () => {
 
 describeIfEndpoint(
   "GET",
-  "/v1/comments/:commentId/replies",
-  "GET /v1/comments/:commentId/replies",
-  () => {
-    it("Return all replies for a comment", async () => {
-      const comment = new CommentModel({
-        content: "this is a comment",
-        ownerId: "useremail@email.com",
-        origin: "123123",
-        refId: 2,
-        applicationId: global.application._id,
-      });
-      await comment.save();
-
-      const commentId = comment._id;
-
-      const res = await request
-        .get(`/v1/comments/${commentId}/replies`)
-        .set("Authorization", `bearer ${global.appToken}`);
-
-      if (res.status === 404) {
-        console.log(
-          `/v1/comments/:commentId/replies, Route Not Implemented Yet`
-        );
-        return true;
-      }
-      expect(res.status).toBe(200);
-      expect(res.body.status).toBe("success");
-      expect(res.body.data).toBeTruthy();
-    });
-  }
-);
-
-describeIfEndpoint(
-  "GET",
   "/v1/comments/:commentId/votes",
   "GET /v1/comments/:commentId/votes",
   () => {

--- a/__test__/api/replies/getAllReplies.test.js
+++ b/__test__/api/replies/getAllReplies.test.js
@@ -158,6 +158,35 @@ describe("get all replies", () => {
     });
   });
 
+  it("given a valid comment ID and filtered by isFlagged for only unflagged replies", () => {
+    const url = `/v1/comments/${comment.id}/replies`;
+    const bearerToken = `bearer ${global.appToken}`;
+
+    const getAllRepliesRequest = request
+      .get(url)
+      .query({ isFlagged: false })
+      .set("Authorization", bearerToken);
+
+    const expectedValue = [
+      {
+        replyId: reply1.id,
+        commentId: reply1.commentId.toString(),
+        ownerId: reply1.ownerId,
+        content: reply1.content,
+        numOfVotes: reply1.upVotes.length + reply1.downVotes.length,
+        numOfUpVotes: reply1.upVotes.length,
+        numOfDownVotes: reply1.downVotes.length,
+        numOfFlags: reply1.flags.length,
+      },
+    ];
+
+    return getAllRepliesRequest.then((res) => {
+      expect(res.status).toEqual(200);
+      expect(res.body.status).toEqual("success");
+      expect(res.body.data).toEqual(expectedValue);
+    });
+  });
+
   it("given an invalid comment ID", () => {
     const url = `/v1/comments/5eff06f9fa2a9a0017469f54/replies`;
     const bearerToken = `bearer ${global.appToken}`;

--- a/__test__/api/replies/getAllReplies.test.js
+++ b/__test__/api/replies/getAllReplies.test.js
@@ -1,0 +1,190 @@
+const app = require("../../../server");
+const ReplyModel = require("../../../models/replies");
+const CommentModel = require("../../../models/comments");
+// const mongoose = require("mongoose");
+const supertest = require("supertest");
+const request = supertest(app);
+
+// Cached comment and reply
+let comment;
+let reply1, reply2;
+
+describe("get all replies", () => {
+  beforeEach(async () => {
+    // Mock a comment document.
+    const mockedCommentDoc = new CommentModel({
+      content: "A comment from user 1",
+      ownerId: "user1@email.com",
+      origin: "123123",
+      refId: 2,
+      applicationId: global.application._id,
+    });
+
+    // Mock a reply document.
+    const mockedReply1Doc = new ReplyModel({
+      content: "A reply from user 2",
+      ownerId: "user2@email.com",
+      commentId: mockedCommentDoc.id,
+    });
+
+    // Mock a reply document.
+    const mockedReply2Doc = new ReplyModel({
+      content: "A reply from user 3",
+      ownerId: "user3@email.com",
+      commentId: mockedCommentDoc.id,
+      flags: [mockedCommentDoc.ownerId],
+    });
+
+    // Save mocked comment document to the database and cache.
+    comment = await mockedCommentDoc.save();
+
+    // Save mocked replies document to the database and cache.
+    reply1 = await mockedReply1Doc.save();
+    reply2 = await mockedReply2Doc.save();
+
+    // Add replies to the mocked comment.
+    await CommentModel.findByIdAndUpdate(comment.id, {
+      $push: {
+        replies: { $each: [reply1.id, reply2.id] },
+      },
+    });
+  });
+
+  afterEach(async () => {
+    // Delete mocks from the database.
+    await CommentModel.findByIdAndDelete(comment.id);
+    await ReplyModel.findByIdAndDelete(reply1.id);
+
+    // Delete cache.
+    comment = null;
+    reply1 = null;
+    reply2 = null;
+  });
+
+  it("given a valid comment ID", () => {
+    const url = `/v1/comments/${comment.id}/replies`;
+    const bearerToken = `bearer ${global.appToken}`;
+
+    const getAllRepliesRequest = request
+      .get(url)
+      .set("Authorization", bearerToken);
+
+    const expectedValue = [
+      {
+        replyId: reply1.id,
+        commentId: reply1.commentId.toString(),
+        ownerId: reply1.ownerId,
+        content: reply1.content,
+        numOfVotes: reply1.upVotes.length + reply1.downVotes.length,
+        numOfUpVotes: reply1.upVotes.length,
+        numOfDownVotes: reply1.downVotes.length,
+        numOfFlags: reply1.flags.length,
+      },
+      {
+        replyId: reply2.id,
+        commentId: reply2.commentId.toString(),
+        ownerId: reply2.ownerId,
+        content: reply2.content,
+        numOfVotes: reply2.upVotes.length + reply2.downVotes.length,
+        numOfUpVotes: reply2.upVotes.length,
+        numOfDownVotes: reply2.downVotes.length,
+        numOfFlags: reply2.flags.length,
+      },
+    ];
+
+    return getAllRepliesRequest.then((res) => {
+      expect(res.status).toEqual(200);
+      expect(res.body.status).toEqual("success");
+      expect(res.body.data).toEqual(expectedValue);
+    });
+  });
+
+  it("given a valid comment ID and filtered by ownerId", () => {
+    const url = `/v1/comments/${comment.id}/replies`;
+    const bearerToken = `bearer ${global.appToken}`;
+
+    const getAllRepliesRequest = request
+      .get(url)
+      .query({ ownerId: reply1.ownerId })
+      .set("Authorization", bearerToken);
+
+    const expectedValue = [
+      {
+        replyId: reply1.id,
+        commentId: reply1.commentId.toString(),
+        ownerId: reply1.ownerId,
+        content: reply1.content,
+        numOfVotes: reply1.upVotes.length + reply1.downVotes.length,
+        numOfUpVotes: reply1.upVotes.length,
+        numOfDownVotes: reply1.downVotes.length,
+        numOfFlags: reply1.flags.length,
+      },
+    ];
+
+    return getAllRepliesRequest.then((res) => {
+      expect(res.status).toEqual(200);
+      expect(res.body.status).toEqual("success");
+      expect(res.body.data).toEqual(expectedValue);
+    });
+  });
+
+  // it("given a valid comment ID and filtered by isFlagged for only flagged replies", () => {
+  //   const url = `/v1/comments/${comment.id}/replies`;
+  //   const bearerToken = `bearer ${global.appToken}`;
+
+  //   const getAllRepliesRequest = request
+  //     .get(url)
+  //     .query({ isFlagged: false })
+  //     .set("Authorization", bearerToken);
+
+  //   const expectedValue = [
+  //     {
+  //       replyId: reply2.id,
+  //       commentId: reply2.commentId.toString(),
+  //       ownerId: reply2.ownerId,
+  //       content: reply2.content,
+  //       numOfVotes: reply2.upVotes.length + reply2.downVotes.length,
+  //       numOfUpVotes: reply2.upVotes.length,
+  //       numOfDownVotes: reply2.downVotes.length,
+  //       numOfFlags: reply2.flags.length,
+  //     },
+  //   ];
+
+  //   return getAllRepliesRequest.then((res) => {
+  //     console.log(res.body.data);
+  //     expect(res.status).toEqual(200);
+  //     expect(res.body.status).toEqual("success");
+  //     expect(res.body.data).toEqual(expectedValue);
+  //   });
+  // });
+
+  it("given an invalid comment ID", () => {
+    const url = `/v1/comments/5eff06f9fa2a9a0017469f54/replies`;
+    const bearerToken = `bearer ${global.appToken}`;
+
+    const getAllRepliesRequest = request
+      .get(url)
+      .set("Authorization", bearerToken);
+
+    return getAllRepliesRequest.then((res) => {
+      expect(res.status).toEqual(404);
+      expect(res.body.status).toEqual("error");
+      expect(res.body.data).toEqual([]);
+    });
+  });
+
+  it("given a valid comment ID but unauthorized bearer token", () => {
+    const url = `/v1/comments/${comment.id}/replies`;
+    const bearerToken = `bearer `;
+
+    const getAllRepliesRequest = request
+      .get(url)
+      .set("Authorization", bearerToken);
+
+    return getAllRepliesRequest.then((res) => {
+      expect(res.status).toEqual(401);
+      expect(res.body.status).toEqual("error");
+      expect(res.body.data).toEqual([]);
+    });
+  });
+});

--- a/__test__/api/replies/getAllReplies.test.js
+++ b/__test__/api/replies/getAllReplies.test.js
@@ -128,35 +128,35 @@ describe("get all replies", () => {
     });
   });
 
-  // it("given a valid comment ID and filtered by isFlagged for only flagged replies", () => {
-  //   const url = `/v1/comments/${comment.id}/replies`;
-  //   const bearerToken = `bearer ${global.appToken}`;
+  it("given a valid comment ID and filtered by isFlagged for only flagged replies", () => {
+    const url = `/v1/comments/${comment.id}/replies`;
+    const bearerToken = `bearer ${global.appToken}`;
 
-  //   const getAllRepliesRequest = request
-  //     .get(url)
-  //     .query({ isFlagged: false })
-  //     .set("Authorization", bearerToken);
+    const getAllRepliesRequest = request
+      .get(url)
+      .query({ isFlagged: true })
+      .set("Authorization", bearerToken);
 
-  //   const expectedValue = [
-  //     {
-  //       replyId: reply2.id,
-  //       commentId: reply2.commentId.toString(),
-  //       ownerId: reply2.ownerId,
-  //       content: reply2.content,
-  //       numOfVotes: reply2.upVotes.length + reply2.downVotes.length,
-  //       numOfUpVotes: reply2.upVotes.length,
-  //       numOfDownVotes: reply2.downVotes.length,
-  //       numOfFlags: reply2.flags.length,
-  //     },
-  //   ];
+    const expectedValue = [
+      {
+        replyId: reply2.id,
+        commentId: reply2.commentId.toString(),
+        ownerId: reply2.ownerId,
+        content: reply2.content,
+        numOfVotes: reply2.upVotes.length + reply2.downVotes.length,
+        numOfUpVotes: reply2.upVotes.length,
+        numOfDownVotes: reply2.downVotes.length,
+        numOfFlags: reply2.flags.length,
+      },
+    ];
 
-  //   return getAllRepliesRequest.then((res) => {
-  //     console.log(res.body.data);
-  //     expect(res.status).toEqual(200);
-  //     expect(res.body.status).toEqual("success");
-  //     expect(res.body.data).toEqual(expectedValue);
-  //   });
-  // });
+    return getAllRepliesRequest.then((res) => {
+      console.log(res.body.data);
+      expect(res.status).toEqual(200);
+      expect(res.body.status).toEqual("success");
+      expect(res.body.data).toEqual(expectedValue);
+    });
+  });
 
   it("given an invalid comment ID", () => {
     const url = `/v1/comments/5eff06f9fa2a9a0017469f54/replies`;

--- a/controllers/repliesController/getAllReplies.js
+++ b/controllers/repliesController/getAllReplies.js
@@ -38,10 +38,12 @@ const getAllReplies = async (req, res, next) => {
     query.commentId = commentId;
     if (ownerId) query.ownerId = ownerId;
 
-    if (!!isFlagged === true) {
-      query = { ...query, flags: { $size: { $gt: 1 } } };
-    } else if (!!isFlagged === false) {
-      query = { ...query, flags: { $size: { $eq: 0 } } };
+    if (typeof isFlagged === "string") {
+      if (isFlagged === "true") {
+        query["flags.0"] = { $exists: true };
+      } else if (isFlagged === "false") {
+        query["flags.0"] = { $exists: false };
+      }
     }
 
     const replies = await Replies.find(query);

--- a/controllers/repliesController/getAllReplies.js
+++ b/controllers/repliesController/getAllReplies.js
@@ -19,6 +19,7 @@ const responseHandler = require("../../utils/responseHandler");
  */
 const getAllReplies = async (req, res, next) => {
   const { commentId } = req.params;
+  const { ownerId } = req.query;
 
   if (!ObjectId.isValid(commentId)) {
     return next(new CustomError(400, " Invalid comment Id "));
@@ -31,9 +32,13 @@ const getAllReplies = async (req, res, next) => {
       return next(new CustomError(404, " Comment not found "));
     }
 
-    const replies = await Replies.find({ commentId: commentId }).populate(
-      "replyOwner"
-    );
+    // Create query for replies.
+    let query = {};
+
+    query.commentId = commentId;
+    if (ownerId) query.ownerId = ownerId;
+
+    const replies = await Replies.find(query);
     let message = " Replies found. ";
     if (!replies.length) {
       message = " No replies found. ";

--- a/controllers/repliesController/getAllReplies.js
+++ b/controllers/repliesController/getAllReplies.js
@@ -19,7 +19,7 @@ const responseHandler = require("../../utils/responseHandler");
  */
 const getAllReplies = async (req, res, next) => {
   const { commentId } = req.params;
-  const { ownerId } = req.query;
+  const { isFlagged, ownerId } = req.query;
 
   if (!ObjectId.isValid(commentId)) {
     return next(new CustomError(400, " Invalid comment Id "));
@@ -37,6 +37,12 @@ const getAllReplies = async (req, res, next) => {
 
     query.commentId = commentId;
     if (ownerId) query.ownerId = ownerId;
+
+    if (!!isFlagged === true) {
+      query = { ...query, flags: { $size: { $gt: 1 } } };
+    } else if (!!isFlagged === false) {
+      query = { ...query, flags: { $size: { $eq: 0 } } };
+    }
 
     const replies = await Replies.find(query);
     let message = " Replies found. ";


### PR DESCRIPTION
**Before submitting your PR for review**

- Run `npm run lint` to find errors in code syntax/format
- Run `npm run lint:fix` to fix all auto-fixable errors in source code and auto-format with prettier
- Ensure you fix any linting errors displayed after running any of the above commands

**What does this PR do?**

Fixes #332 

This PR implements a test suite that will cover all required functionality expected from the getAllReplies endpoint /v1/comments/{commentId}/replies. For each test that doesn't pass, the controller method (along with its validation schema and swagger docs if the modifications require it) will be modified to include the required functionalities so that the test passes.

**description of Task to be completed?**

- [x] test that valid comment ID returns with the list of replies and status 200
- [x] test that valid comment ID filtered by ownerId returns with the filtered list response and status 200
- [x] test that valid comment ID filtered by isFlagged returns with the filtered list response and status 200
- [x] test that a valid comment ID with an unauthorized token returns with correct error response and status 401
- [x] test that invalid comment ID returns with correct error response and status 404

**How should this be manually tested?**

- In your terminal, run `npm test`

**Any background context you want to provide?**

None

**What is the link to the issue on Github?**

[Issue #332](https://github.com/microapidev/comment-microapi/issues/332)

**Questions:**

I am having trouble implementing the query for filtering by whether or not a reply has a flag or not for the isFlagged query parameter. I am hoping that someone with better knowledge on Mongo can help with making this query possible in an efficient way.