### PR TITLE
[FIX] getAllComments API Endpoint Tests

### DIFF
--- a/__test__/api/comments/getAllComments.test.js
+++ b/__test__/api/comments/getAllComments.test.js
@@ -76,13 +76,13 @@ describe("GET /comments", () => {
     const url = `/v1/comments`;
     const bearerToken = `bearer ${global.appToken}`;
 
-    const getAllRepliesRequest = request
+    const getAllCommentsRequest = request
       .get(url)
       .set("Authorization", bearerToken);
 
     const expectedValue = [comment1, comment2];
 
-    return getAllRepliesRequest.then((res) => {
+    return getAllCommentsRequest.then((res) => {
       expect(res.status).toEqual(200);
       expect(res.body.status).toEqual("success");
       expect(res.body.data).toEqual(expectedValue);
@@ -93,14 +93,14 @@ describe("GET /comments", () => {
     const url = `/v1/comments`;
     const bearerToken = `bearer ${global.appToken}`;
 
-    const getAllRepliesRequest = request
+    const getAllCommentsRequest = request
       .get(url)
       .query({ ownerId: comment1.ownerId })
       .set("Authorization", bearerToken);
 
     const expectedValue = [comment1];
 
-    return getAllRepliesRequest.then((res) => {
+    return getAllCommentsRequest.then((res) => {
       expect(res.status).toEqual(200);
       expect(res.body.status).toEqual("success");
       expect(res.body.data).toEqual(expectedValue);
@@ -111,14 +111,14 @@ describe("GET /comments", () => {
     const url = `/v1/comments`;
     const bearerToken = `bearer ${global.appToken}`;
 
-    const getAllRepliesRequest = request
+    const getAllCommentsRequest = request
       .get(url)
       .query({ refId: comment2.refId })
       .set("Authorization", bearerToken);
 
     const expectedValue = [comment2];
 
-    return getAllRepliesRequest.then((res) => {
+    return getAllCommentsRequest.then((res) => {
       expect(res.status).toEqual(200);
       expect(res.body.status).toEqual("success");
       expect(res.body.data).toEqual(expectedValue);
@@ -129,14 +129,14 @@ describe("GET /comments", () => {
     const url = `/v1/comments`;
     const bearerToken = `bearer ${global.appToken}`;
 
-    const getAllRepliesRequest = request
+    const getAllCommentsRequest = request
       .get(url)
       .query({ origin: comment1.origin })
       .set("Authorization", bearerToken);
 
     const expectedValue = [comment1];
 
-    return getAllRepliesRequest.then((res) => {
+    return getAllCommentsRequest.then((res) => {
       expect(res.status).toEqual(200);
       expect(res.body.status).toEqual("success");
       expect(res.body.data).toEqual(expectedValue);
@@ -147,14 +147,14 @@ describe("GET /comments", () => {
     const url = `/v1/comments`;
     const bearerToken = `bearer ${global.appToken}`;
 
-    const getAllRepliesRequest = request
+    const getAllCommentsRequest = request
       .get(url)
       .query({ isFlagged: true })
       .set("Authorization", bearerToken);
 
     const expectedValue = [comment2];
 
-    return getAllRepliesRequest.then((res) => {
+    return getAllCommentsRequest.then((res) => {
       expect(res.status).toEqual(200);
       expect(res.body.status).toEqual("success");
       expect(res.body.data).toEqual(expectedValue);
@@ -165,14 +165,14 @@ describe("GET /comments", () => {
     const url = `/v1/comments`;
     const bearerToken = `bearer ${global.appToken}`;
 
-    const getAllRepliesRequest = request
+    const getAllCommentsRequest = request
       .get(url)
       .query({ isFlagged: false })
       .set("Authorization", bearerToken);
 
     const expectedValue = [comment1];
 
-    return getAllRepliesRequest.then((res) => {
+    return getAllCommentsRequest.then((res) => {
       expect(res.status).toEqual(200);
       expect(res.body.status).toEqual("success");
       expect(res.body.data).toEqual(expectedValue);
@@ -183,11 +183,11 @@ describe("GET /comments", () => {
     const url = `/v1/comments`;
     const bearerToken = `bearer `;
 
-    const getAllRepliesRequest = request
+    const getAllCommentsRequest = request
       .get(url)
       .set("Authorization", bearerToken);
 
-    return getAllRepliesRequest.then((res) => {
+    return getAllCommentsRequest.then((res) => {
       expect(res.status).toEqual(401);
       expect(res.body.status).toEqual("error");
       expect(res.body.data).toEqual([]);

--- a/__test__/api/comments/getAllComments.test.js
+++ b/__test__/api/comments/getAllComments.test.js
@@ -7,7 +7,7 @@ const request = supertest(app);
 // Cached comment and reply responses
 let comment1, comment2;
 
-describe("get all comments", () => {
+describe("GET /comments", () => {
   beforeEach(async () => {
     // Mock a comment document.
     const mockedComment1Doc = new CommentModel({
@@ -72,7 +72,7 @@ describe("get all comments", () => {
     comment2 = null;
   });
 
-  it("given a valid request", () => {
+  it("Should get all comments", () => {
     const url = `/v1/comments`;
     const bearerToken = `bearer ${global.appToken}`;
 
@@ -89,7 +89,7 @@ describe("get all comments", () => {
     });
   });
 
-  it("given a valid request and filtered by ownerId", () => {
+  it("Should get all comments with a certain ownerId", () => {
     const url = `/v1/comments`;
     const bearerToken = `bearer ${global.appToken}`;
 
@@ -107,7 +107,7 @@ describe("get all comments", () => {
     });
   });
 
-  it("given a valid request and filtered by refId", () => {
+  it("Should get all comments with a certain refId", () => {
     const url = `/v1/comments`;
     const bearerToken = `bearer ${global.appToken}`;
 
@@ -125,7 +125,7 @@ describe("get all comments", () => {
     });
   });
 
-  it("given a valid request and filtered by origin", () => {
+  it("Should get all comments with a certain origin", () => {
     const url = `/v1/comments`;
     const bearerToken = `bearer ${global.appToken}`;
 
@@ -143,7 +143,7 @@ describe("get all comments", () => {
     });
   });
 
-  it("given a valid request and filtered by isFlagged for only flagged replies", () => {
+  it("Should get all comments that are flagged", () => {
     const url = `/v1/comments`;
     const bearerToken = `bearer ${global.appToken}`;
 
@@ -161,7 +161,7 @@ describe("get all comments", () => {
     });
   });
 
-  it("given a valid comment ID and filtered by isFlagged for only unflagged replies", () => {
+  it("Should get all comments that are unflagged", () => {
     const url = `/v1/comments`;
     const bearerToken = `bearer ${global.appToken}`;
 
@@ -179,7 +179,7 @@ describe("get all comments", () => {
     });
   });
 
-  it("given a valid comment ID but unauthorized bearer token", () => {
+  it("Should return a 401 error when authorization token is unauthorized", () => {
     const url = `/v1/comments`;
     const bearerToken = `bearer `;
 

--- a/__test__/api/comments/getAllComments.test.js
+++ b/__test__/api/comments/getAllComments.test.js
@@ -1,0 +1,196 @@
+const app = require("../../../server");
+const CommentModel = require("../../../models/comments");
+// const mongoose = require("mongoose");
+const supertest = require("supertest");
+const request = supertest(app);
+
+// Cached comment and reply responses
+let comment1, comment2;
+
+describe("get all comments", () => {
+  beforeEach(async () => {
+    // Mock a comment document.
+    const mockedComment1Doc = new CommentModel({
+      content: "A comment from user 1",
+      ownerId: "user1@email.com",
+      origin: "123123",
+      refId: 1,
+      applicationId: global.application._id,
+    });
+
+    // Mock a comment document.
+    const mockedComment2Doc = new CommentModel({
+      content: "A comment from user 2",
+      ownerId: "user2@email.com",
+      origin: "135135",
+      refId: 2,
+      applicationId: global.application._id,
+      flags: ["flagger@gmail.com"],
+    });
+
+    // Save mocked comment document to the database.
+    const savedComment1 = await mockedComment1Doc.save();
+    const savedComment2 = await mockedComment2Doc.save();
+
+    // Cache response objects
+    comment1 = {
+      commentId: savedComment1.id,
+      applicationId: savedComment1.applicationId.toString(),
+      refId: savedComment1.refId,
+      ownerId: savedComment1.ownerId,
+      content: savedComment1.content,
+      origin: savedComment1.origin,
+      numOfReplies: savedComment1.replies.length,
+      numOfVotes: savedComment1.upVotes.length + savedComment1.downVotes.length,
+      numOfUpVotes: savedComment1.upVotes.length,
+      numOfDownVotes: savedComment1.downVotes.length,
+      numOfFlags: savedComment1.flags.length,
+    };
+
+    comment2 = {
+      commentId: savedComment2.id,
+      applicationId: savedComment2.applicationId.toString(),
+      refId: savedComment2.refId,
+      ownerId: savedComment2.ownerId,
+      content: savedComment2.content,
+      origin: savedComment2.origin,
+      numOfReplies: savedComment2.replies.length,
+      numOfVotes: savedComment2.upVotes.length + savedComment2.downVotes.length,
+      numOfUpVotes: savedComment2.upVotes.length,
+      numOfDownVotes: savedComment2.downVotes.length,
+      numOfFlags: savedComment2.flags.length,
+    };
+  });
+
+  afterEach(async () => {
+    // Delete mocks from the database.
+    await CommentModel.findByIdAndDelete(comment1.commentId);
+    await CommentModel.findByIdAndDelete(comment2.commentId);
+
+    // Delete cache.
+    comment1 = null;
+    comment2 = null;
+  });
+
+  it("given a valid request", () => {
+    const url = `/v1/comments`;
+    const bearerToken = `bearer ${global.appToken}`;
+
+    const getAllRepliesRequest = request
+      .get(url)
+      .set("Authorization", bearerToken);
+
+    const expectedValue = [comment1, comment2];
+
+    return getAllRepliesRequest.then((res) => {
+      expect(res.status).toEqual(200);
+      expect(res.body.status).toEqual("success");
+      expect(res.body.data).toEqual(expectedValue);
+    });
+  });
+
+  it("given a valid request and filtered by ownerId", () => {
+    const url = `/v1/comments`;
+    const bearerToken = `bearer ${global.appToken}`;
+
+    const getAllRepliesRequest = request
+      .get(url)
+      .query({ ownerId: comment1.ownerId })
+      .set("Authorization", bearerToken);
+
+    const expectedValue = [comment1];
+
+    return getAllRepliesRequest.then((res) => {
+      expect(res.status).toEqual(200);
+      expect(res.body.status).toEqual("success");
+      expect(res.body.data).toEqual(expectedValue);
+    });
+  });
+
+  it("given a valid request and filtered by refId", () => {
+    const url = `/v1/comments`;
+    const bearerToken = `bearer ${global.appToken}`;
+
+    const getAllRepliesRequest = request
+      .get(url)
+      .query({ refId: comment2.refId })
+      .set("Authorization", bearerToken);
+
+    const expectedValue = [comment2];
+
+    return getAllRepliesRequest.then((res) => {
+      expect(res.status).toEqual(200);
+      expect(res.body.status).toEqual("success");
+      expect(res.body.data).toEqual(expectedValue);
+    });
+  });
+
+  it("given a valid request and filtered by origin", () => {
+    const url = `/v1/comments`;
+    const bearerToken = `bearer ${global.appToken}`;
+
+    const getAllRepliesRequest = request
+      .get(url)
+      .query({ origin: comment1.origin })
+      .set("Authorization", bearerToken);
+
+    const expectedValue = [comment1];
+
+    return getAllRepliesRequest.then((res) => {
+      expect(res.status).toEqual(200);
+      expect(res.body.status).toEqual("success");
+      expect(res.body.data).toEqual(expectedValue);
+    });
+  });
+
+  it("given a valid request and filtered by isFlagged for only flagged replies", () => {
+    const url = `/v1/comments`;
+    const bearerToken = `bearer ${global.appToken}`;
+
+    const getAllRepliesRequest = request
+      .get(url)
+      .query({ isFlagged: true })
+      .set("Authorization", bearerToken);
+
+    const expectedValue = [comment2];
+
+    return getAllRepliesRequest.then((res) => {
+      expect(res.status).toEqual(200);
+      expect(res.body.status).toEqual("success");
+      expect(res.body.data).toEqual(expectedValue);
+    });
+  });
+
+  it("given a valid comment ID and filtered by isFlagged for only unflagged replies", () => {
+    const url = `/v1/comments`;
+    const bearerToken = `bearer ${global.appToken}`;
+
+    const getAllRepliesRequest = request
+      .get(url)
+      .query({ isFlagged: false })
+      .set("Authorization", bearerToken);
+
+    const expectedValue = [comment1];
+
+    return getAllRepliesRequest.then((res) => {
+      expect(res.status).toEqual(200);
+      expect(res.body.status).toEqual("success");
+      expect(res.body.data).toEqual(expectedValue);
+    });
+  });
+
+  it("given a valid comment ID but unauthorized bearer token", () => {
+    const url = `/v1/comments`;
+    const bearerToken = `bearer `;
+
+    const getAllRepliesRequest = request
+      .get(url)
+      .set("Authorization", bearerToken);
+
+    return getAllRepliesRequest.then((res) => {
+      expect(res.status).toEqual(401);
+      expect(res.body.status).toEqual("error");
+      expect(res.body.data).toEqual([]);
+    });
+  });
+});

--- a/controllers/commentsController/getAllComments.js
+++ b/controllers/commentsController/getAllComments.js
@@ -16,14 +16,26 @@ const responseHandler = require("../../utils/responseHandler");
  */
 const getAllComments = async (req, res, next) => {
   const { applicationId } = req.token; //this will be retrieved from decoded api token after full auth implementation
-
   const { refId, origin, ownerId, isFlagged } = req.query;
+
   let query = {};
+
+  query.applicationId = applicationId;
+
   if (refId) query.refId = refId;
-  if (origin) query.commentOrigin = origin;
+  if (origin) query.origin = origin;
   if (ownerId) query.ownerId = ownerId;
+
+  if (typeof isFlagged === "string") {
+    if (isFlagged === "true") {
+      query["flags.0"] = { $exists: true };
+    } else if (isFlagged === "false") {
+      query["flags.0"] = { $exists: false };
+    }
+  }
+
   try {
-    await Comments.find({ applicationId: applicationId })
+    await Comments.find(query)
       .populate("replies")
       .then((comments) => {
         const allComments = comments.map((comment) => {
@@ -44,24 +56,7 @@ const getAllComments = async (req, res, next) => {
           };
         });
 
-        const flaggedComments = [];
-        allComments.forEach((comments) => {
-          if (comments.numOfFlags > 0) {
-            return flaggedComments.push(comments);
-          }
-        });
-
-        const unflaggedComments = [];
-        allComments.forEach((comments) => {
-          if (comments.numOfFlags == 0) {
-            return unflaggedComments.push(comments);
-          }
-        });
-
-        // This logic is used to handle the optional isFlagged paramter
         let data = allComments;
-        if (isFlagged === "true") data = flaggedComments;
-        if (isFlagged === "false") data = unflaggedComments;
 
         responseHandler(
           res,


### PR DESCRIPTION
**Before submitting your PR for review**

- Run `npm run lint` to find errors in code syntax/format
- Run `npm run lint:fix` to fix all auto-fixable errors in source code and auto-format with prettier
- Ensure you fix any linting errors displayed after running any of the above commands

**What does this PR do?**

Fixes #336 

This PR implements a test suite that will cover all required functionality expected from the getAllComments endpoint /v1/comments. For each test that doesn't pass, the controller method (along with its validation schema and swagger docs if the modifications require it) will be modified to include the required functionalities so that the test passes.

**description of Task to be completed?**

- [x] test that a request returns with the full list response and status 200
- [x] test that a request filtered by refId returns with the filtered list response and status 200
- [x] test that a request filtered by ownerId returns with the filtered list response and status 200
- [x] test that a request filtered by isFlagged returns with the filtered list response and status 200
- [x] test that a request filtered by origin returns with the filtered list response and status 200
- [x] test that a request with an unauthorized token returns with correct error response and status 401

**How should this be manually tested?**

- In your terminal, run `npm test`

**Any background context you want to provide?**

None

**What is the link to the issue on Github?**

[Issue #336](https://github.com/microapidev/comment-microapi/issues/336)

**Questions:**
None