### PR TITLE
Add integration test for delete comment endpoint

### DIFF
--- a/__test__/api/comments/deleteSingleComment.test.js
+++ b/__test__/api/comments/deleteSingleComment.test.js
@@ -1,0 +1,94 @@
+const app = require("../../../server");
+const supertest = require("supertest");
+const CommentModel = require("../../../models/comments");
+const commentHandler = require("../../../utils/commentHandler");
+const request = supertest(app);
+
+describe("DELETE /v1/comments/:commentId", () => {
+  let comment;
+
+  beforeEach(async () => {
+    comment = new CommentModel({
+      refId: "4edd40c86762e0fb12000003",
+      applicationId: global.application._id,
+      content: "A mock comment from user1",
+      ownerId: "user1@email.com",
+      origin: "b12000003",
+    });
+    await comment.save();
+  });
+
+  afterEach(async () => {
+    await CommentModel.findByIdAndDelete(comment._id);
+    comment = null;
+  });
+
+  // 200 success
+  test("Should delete a comment", async () => {
+    const expected = commentHandler(comment);
+    const res = await request
+      .delete(`/v1/comments/${expected.commentId}`)
+      .set("Authorization", `bearer ${global.appToken}`)
+      .send({
+        ownerId: expected.ownerId,
+      });
+
+    expect(res.status).toBe(200);
+    expect(res.body.status).toEqual("success");
+    expect(res.body.data).toMatchObject(expected);
+  });
+
+  // 404 not found error
+  test("Should return not found error when commentId not in db", async () => {
+    const res = await request
+      .delete("/v1/comments/4edd40c86762e0fb12000003")
+      .set("Authorization", `bearer ${global.appToken}`)
+      .send({
+        ownerId: "rogueuser@email.com",
+      });
+
+    expect(res.status).toBe(404);
+    expect(res.body.status).toEqual("error");
+    expect(res.body.error).toBeTruthy();
+  });
+
+  // 404 not found error
+  test("Should return not found error when commentId not match ObjectId", async () => {
+    const res = await request
+      .delete("/v1/comments/62e0fb12000003")
+      .set("Authorization", `bearer ${global.appToken}`)
+      .send({
+        ownerId: "rogueuser@email.com",
+      });
+
+    expect(res.status).toBe(404);
+    expect(res.body.status).toEqual("error");
+    expect(res.body.error).toBeTruthy();
+  });
+
+  // 422 validation error
+  test("Should return validation error when ownerId is missing", async () => {
+    const expected = commentHandler(comment);
+    const res = await request
+      .delete(`/v1/comments/${expected.commentId}`)
+      .set("Authorization", `bearer ${global.appToken}`);
+
+    expect(res.status).toBe(422);
+    expect(res.body.status).toEqual("error");
+    expect(res.body.error).toBeTruthy();
+  });
+
+  // 401 unauthorized requests
+  test("Should return authentication error when invalid token", async () => {
+    const res = await request
+      .delete(`/v1/comments/4edd40c86762e0fb12000003`)
+      .set("Authorization", "bearer 4edd40c86762e0fb12000003")
+      .send({
+        ownerId: "rogueuser@email.com",
+      });
+
+    expect(res.status).toBe(401);
+    expect(res.body.status).toEqual("error");
+    expect(res.body.error).toBeTruthy();
+  });
+});

--- a/__test__/api/comments/deleteSingleComment.test.js
+++ b/__test__/api/comments/deleteSingleComment.test.js
@@ -26,6 +26,10 @@ describe("DELETE /v1/comments/:commentId", () => {
   // 200 success
   test("Should delete a comment", async () => {
     const expected = commentHandler(comment);
+    CommentModel.findById(expected.commentId).then((item) => {
+      expect(commentHandler(item)).toMatchObject(expected);
+    });
+
     const res = await request
       .delete(`/v1/comments/${expected.commentId}`)
       .set("Authorization", `bearer ${global.appToken}`)
@@ -36,6 +40,10 @@ describe("DELETE /v1/comments/:commentId", () => {
     expect(res.status).toBe(200);
     expect(res.body.status).toEqual("success");
     expect(res.body.data).toMatchObject(expected);
+
+    CommentModel.findById(expected.commentId).then((item) => {
+      expect(item).toBeNull();
+    });
   });
 
   // 404 not found error

--- a/controllers/commentsController/deleteSingleComment.js
+++ b/controllers/commentsController/deleteSingleComment.js
@@ -1,4 +1,5 @@
 const Comments = require("../../models/comments");
+const { ObjectId } = require("mongoose").Types;
 
 // Utilities
 const CustomError = require("../../utils/customError");
@@ -19,41 +20,28 @@ const deleteSingleComment = async (req, res, next) => {
   const ownerId = req.body.ownerId;
   const { applicationId } = req.token;
 
+  if (!ObjectId.isValid(applicationId))
+    return next(new CustomError(401, "unauthorised request"));
+  if (!ObjectId.isValid(commentId))
+    return next(new CustomError(404, "Comment not found"));
+  if (!ownerId) return next(new CustomError(422, "invalid reply id"));
+
   try {
     //find comment in application
-    const comment = await Comments.findOne({
+    const comment = await Comments.findOneAndDelete({
       _id: commentId,
       applicationId: applicationId,
     });
     if (!comment) {
-      return next(new CustomError(400, "Comment not found"));
+      return next(new CustomError(404, "Comment not found"));
     }
-    if (comment.ownerId === ownerId) {
-      const deleting = await Comments.findByIdAndDelete(commentId);
-      if (deleting) {
-        responseHandler(
-          res,
-          200,
-          commentHandler(deleting),
-          "Comment deleted successfully"
-        );
-        return;
-      } else {
-        return next(
-          new CustomError(
-            400,
-            "Cannot delete your comment at this time. Please try again"
-          )
-        );
-      }
-    } else {
-      return next(
-        new CustomError(
-          400,
-          "Comment cannot be deleted because you are not the owner of this comment."
-        )
-      );
-    }
+    //const deleting = await Comments.findByIdAndDelete(commentId);
+    return responseHandler(
+      res,
+      200,
+      commentHandler(comment),
+      "Comment successfully deleted"
+    );
   } catch (error) {
     return next(error);
   }


### PR DESCRIPTION
**Before submitting your PR for review**

- [x] Run `npm run lint` to find errors in code syntax/format
- [x] Run `npm run lint:fix` to fix all auto-fixable errors in source code and auto-format with prettier
- [x] Ensure you fix any linting errors displayed after running any of the above commands

**What does this PR do?**

Resolve #341

**description of Task to be completed?**

- test status 200 success
- test status 404 commentId not found/invalid
- test status 422 ownerId missing in request
- test status 401 unauthorized request
- update delete comments controller as required

**How should this be manually tested?**

```bash
npm install
npm run test
```

**Any background context you want to provide?**

**What is the link to the issue on Github?**

Issue #341

**Questions:**