### PR TITLE
[FIX] updateSingleComment API Endpoint Tests

### DIFF
--- a/__test__/api/comment-patch.test.js
+++ b/__test__/api/comment-patch.test.js
@@ -8,35 +8,6 @@ const { describeIfEndpoint } = require("../helpers/conditionalTests");
 
 describeIfEndpoint(
   "PATCH",
-  "/v1/comments/:commentId",
-  "PATCH /v1/comments/:commentId",
-  () => {
-    it("Updates a comment", async () => {
-      const comment = new CommentModel({
-        content: "this is a comment",
-        ownerId: "useremail@email.com",
-        origin: "123123",
-        applicationId: global.application._id,
-      });
-      await comment.save();
-
-      const res = await request
-        .patch(`/v1/comments/${comment._id}`)
-        .set("Authorization", `bearer ${global.appToken}`)
-        .send({
-          ownerId: comment.ownerId,
-          content: "New Comment Update",
-        });
-
-      expect(res.status).toBe(200);
-      expect(res.body.data.content).toBeTruthy();
-      expect(res.body.data.ownerId).toBeTruthy();
-    });
-  }
-);
-
-describeIfEndpoint(
-  "PATCH",
   "/v1/comments/:commentId/flag",
   "PATCH /v1/comments/:commentId/flag",
   () => {

--- a/__test__/api/comments/updateSingleComment.test.js
+++ b/__test__/api/comments/updateSingleComment.test.js
@@ -81,4 +81,38 @@ describe("PATCH /comments/:commentId", () => {
       expect(comment.content).toEqual(contentUpdate);
     });
   });
+
+  it("Should return a 401 error when the authorization header's token is unauthorized", async () => {
+    const url = `/v1/comments/${oldComment.commentId}`;
+    const bearerToken = `bearer `;
+
+    const res = await request
+      .patch(url)
+      .set("Authorization", bearerToken)
+      .send({
+        ownerId: oldComment.ownerId,
+        content: "content",
+      });
+
+    expect(res.status).toEqual(401);
+    expect(res.body.status).toEqual("error");
+    expect(res.body.data).toEqual([]);
+  });
+
+  it("Should return a 404 error when the commentId path parameter is invalid", async () => {
+    const url = `/v1/comments/4edd30e86762e0fb12000003`;
+    const bearerToken = `bearer ${global.appToken}`;
+
+    const res = await request
+      .patch(url)
+      .set("Authorization", bearerToken)
+      .send({
+        ownerId: oldComment.ownerId,
+        content: "content",
+      });
+
+    expect(res.status).toEqual(404);
+    expect(res.body.status).toEqual("error");
+    expect(res.body.data).toEqual([]);
+  });
 });

--- a/__test__/api/comments/updateSingleComment.test.js
+++ b/__test__/api/comments/updateSingleComment.test.js
@@ -1,0 +1,84 @@
+const app = require("../../../server");
+const CommentModel = require("../../../models/comments");
+// const mongoose = require("mongoose");
+const supertest = require("supertest");
+const request = supertest(app);
+
+// Cached comment responses
+let oldComment;
+
+describe("PATCH /comments/:commentId", () => {
+  beforeEach(async () => {
+    // Mock a comment document.
+    const mockedOldCommentDoc = new CommentModel({
+      content: "A comment from user 1",
+      ownerId: "user1@email.com",
+      origin: "135135",
+      refId: 1,
+      applicationId: global.application._id,
+      flags: ["flagger@gmail.com"],
+    });
+
+    // Save mocked comment document to the database.
+    const savedOldComment = await mockedOldCommentDoc.save();
+
+    // Cache response objects
+    oldComment = {
+      commentId: savedOldComment.id,
+      applicationId: savedOldComment.applicationId.toString(),
+      refId: savedOldComment.refId,
+      ownerId: savedOldComment.ownerId,
+      content: savedOldComment.content,
+      origin: savedOldComment.origin,
+      numOfReplies: savedOldComment.replies.length,
+      numOfVotes:
+        savedOldComment.upVotes.length + savedOldComment.downVotes.length,
+      numOfUpVotes: savedOldComment.upVotes.length,
+      numOfDownVotes: savedOldComment.downVotes.length,
+      numOfFlags: savedOldComment.flags.length,
+    };
+  });
+
+  afterEach(async () => {
+    // Delete mocks from the database.
+    await CommentModel.findByIdAndDelete(oldComment.commentId);
+
+    // Delete cache.
+    oldComment = null;
+  });
+
+  it("Should update a comment", async () => {
+    const url = `/v1/comments/${oldComment.commentId}`;
+    const bearerToken = `bearer ${global.appToken}`;
+    const contentUpdate = "New Comment Update";
+
+    // Run test matchers to verify that the comment has not been updated in the database.
+    await CommentModel.findById(oldComment.commentId).then((comment) => {
+      expect(comment).toBeTruthy();
+      expect(comment.content).toEqual(oldComment.content);
+    });
+
+    // Run test matchers to verify that the comment update produced the correct success response.
+    const res = await request
+      .patch(url)
+      .set("Authorization", bearerToken)
+      .send({
+        ownerId: oldComment.ownerId,
+        content: contentUpdate,
+      });
+
+    expect(res.status).toEqual(200);
+    expect(res.body.status).toEqual("success");
+    expect(res.body.data).toEqual({
+      ownerId: oldComment.ownerId,
+      content: contentUpdate,
+    });
+
+    // Run test matchers to verify that the comment has been updated in the database.
+    await CommentModel.findById(oldComment.commentId).then((comment) => {
+      expect(comment).toBeTruthy();
+      expect(comment.content).not.toEqual(oldComment.content);
+      expect(comment.content).toEqual(contentUpdate);
+    });
+  });
+});

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -1033,9 +1033,7 @@ paths:
                   status:
                     type: string
                   data:
-                    type: array
-                    items:
-                      $ref: "#/components/schemas/UpdateComment"
+                    $ref: "#/components/schemas/UpdateComment"
 
         "400":
           description: Bad request error

--- a/routes/comments.js
+++ b/routes/comments.js
@@ -64,7 +64,7 @@ router.get(
  */
 router.patch(
   "/:commentId",
-  validationMiddleware(validationRules.updateCommentSchema),
+  validationMiddleware(validationRules.updateSingleCommentSchema),
   commentsController.updateSingleComment
 );
 

--- a/utils/validationRules/comments/updateSingleCommentSchema.js
+++ b/utils/validationRules/comments/updateSingleCommentSchema.js
@@ -3,7 +3,7 @@ const Joi = require("@hapi/joi");
 /**
  * Schema validation for PATCH '/comments/{commentId}'
  */
-const updateCommentSchema = {
+const updateSingleCommentSchema = {
   headers: Joi.object({
     authorization: Joi.string().required(),
   }),
@@ -13,9 +13,9 @@ const updateCommentSchema = {
   }),
 
   body: Joi.object().keys({
-    content: Joi.string().min(1),
+    content: Joi.string().min(1).required(),
     ownerId: Joi.string().required(),
   }),
 };
 
-module.exports = updateCommentSchema;
+module.exports = updateSingleCommentSchema;

--- a/utils/validationRules/index.js
+++ b/utils/validationRules/index.js
@@ -1,7 +1,7 @@
 const getAllCommentsSchema = require("./comments/getAllCommentsSchema");
 const createCommentSchema = require("./comments/createCommentSchema");
 const getSingleCommentSchema = require("./comments/getSingleCommentSchema");
-const updateCommentSchema = require("./comments/updateCommentSchema");
+const updateSingleCommentSchema = require("./comments/updateSingleCommentSchema");
 const deleteCommentSchema = require("./comments/deleteCommentSchema");
 const getCommentVotesSchema = require("./comments/getCommentVotesSchema");
 const updateCommentUpAndDownVoteSchema = require("./comments/updateCommentUpAndDownVoteSchema");
@@ -39,7 +39,7 @@ module.exports = {
   getAllCommentsSchema,
   createCommentSchema,
   getSingleCommentSchema,
-  updateCommentSchema,
+  updateSingleCommentSchema,
   deleteCommentSchema,
   getCommentVotesSchema,
   updateCommentUpAndDownVoteSchema,


### PR DESCRIPTION
**Before submitting your PR for review**

- Run `npm run lint` to find errors in code syntax/format
- Run `npm run lint:fix` to fix all auto-fixable errors in source code and auto-format with prettier
- Ensure you fix any linting errors displayed after running any of the above commands

**What does this PR do?**

Fixes #346 

This PR implements a test suite that will cover all required functionality expected from the updateSingleComment endpoint /v1/comments/{commentId}. For each test that doesn't pass, the controller method (along with its validation schema and swagger docs if the modifications require it) will be modified to include the required functionalities so that the test passes.

**description of Task to be completed?**

- [x] test that a request returns with the correct update response and status 200
- [x] test that a request with an unauthorized token returns with correct error response and status 401
- [x] test that a request with an invalid ID returns with correct error response and status 404
- [x] test that a request with a missing "content" returns with correct error response and status 422
- [x] test that a request with a "content" of less than 1 returns with correct error response and status 422
- [x] test that a request with a missing "ownerId" returns with correct error response and status 422

**How should this be manually tested?**

- In your terminal, run `npm test`

**Any background context you want to provide?**

None

**What is the link to the issue on Github?**

[Issue #346](https://github.com/microapidev/comment-microapi/issues/346)

**Questions:**
None