### PR TITLE
[FIX] updateSingleReply API Endpoint Tests

### DIFF
--- a/__test__/api/replies/updateSingleReply.test.js
+++ b/__test__/api/replies/updateSingleReply.test.js
@@ -10,7 +10,7 @@ const request = supertest(app);
 // Cached comment and reply responses
 let oldComment, oldReply;
 
-describe("PATCH /comments/:commentId", () => {
+describe("PATCH /comments/:commentId/replies/:replyId", () => {
   beforeEach(async () => {
     // Mock a comment document.
     const mockedCommentDoc = new CommentModel({
@@ -110,21 +110,34 @@ describe("PATCH /comments/:commentId", () => {
     expect(res.body.data).toEqual([]);
   });
 
-  it("Should return a 404 error when the commentId path parameter is invalid", async () => {
-    const url = `/v1/comments/${oldComment.commentId}/replies/4edd30e86762e0fb12000003`;
+  it("Should return a 404 error when the commentId or replyId path parameter is invalid", async () => {
+    const invalidCommentUrl = `/v1/comments/4edd30e86762e0fb12000003/replies/${oldReply.replyId}`;
+    const invalidReplyUrl = `/v1/comments/${oldComment.commentId}/replies/4edd30e86762e0fb12000003`;
     const bearerToken = `bearer ${global.appToken}`;
 
-    const res = await request
-      .patch(url)
+    const invalidCommentRes = await request
+      .patch(invalidCommentUrl)
       .set("Authorization", bearerToken)
       .send({
         ownerId: oldReply.ownerId,
         content: "content",
       });
 
-    expect(res.status).toEqual(404);
-    expect(res.body.status).toEqual("error");
-    expect(res.body.data).toEqual([]);
+    expect(invalidCommentRes.status).toEqual(404);
+    expect(invalidCommentRes.body.status).toEqual("error");
+    expect(invalidCommentRes.body.data).toEqual([]);
+
+    const invalidReplyRes = await request
+      .patch(invalidReplyUrl)
+      .set("Authorization", bearerToken)
+      .send({
+        ownerId: oldReply.ownerId,
+        content: "content",
+      });
+
+    expect(invalidReplyRes.status).toEqual(404);
+    expect(invalidReplyRes.body.status).toEqual("error");
+    expect(invalidReplyRes.body.data).toEqual([]);
   });
 
   it("Should return a 422 error when the content body property is missing or invalid", async () => {

--- a/__test__/api/replies/updateSingleReply.test.js
+++ b/__test__/api/replies/updateSingleReply.test.js
@@ -1,0 +1,185 @@
+const app = require("../../../server");
+const CommentModel = require("../../../models/comments");
+const ReplyModel = require("../../../models/replies");
+const commentHandler = require("../../../utils/commentHandler");
+const replyHandler = require("../../../utils/replyHandler");
+// const mongoose = require("mongoose");
+const supertest = require("supertest");
+const request = supertest(app);
+
+// Cached comment and reply responses
+let oldComment, oldReply;
+
+describe("PATCH /comments/:commentId", () => {
+  beforeEach(async () => {
+    // Mock a comment document.
+    const mockedCommentDoc = new CommentModel({
+      content: "A comment from user 1",
+      ownerId: "user1@email.com",
+      origin: "135135",
+      refId: 1,
+      applicationId: global.application._id,
+      flags: ["flagger@gmail.com"],
+    });
+
+    // Mock a reply document.
+    const mockedReplyDoc = new ReplyModel({
+      content: "A reply from user 3",
+      ownerId: "user3@email.com",
+      commentId: mockedCommentDoc.id,
+      flags: [mockedCommentDoc.ownerId],
+    });
+
+    // Save mocked comment document to the database.
+    const savedComment = await mockedCommentDoc.save();
+
+    // Save mocked replies document to the database.
+    const savedReply = await mockedReplyDoc.save();
+
+    // Add replies to the mocked comment.
+    await CommentModel.findByIdAndUpdate(savedComment.id, {
+      $push: {
+        replies: { $each: [savedReply.id] },
+      },
+    });
+
+    // Cache response objects
+    oldComment = commentHandler(savedComment);
+    oldReply = replyHandler(savedReply);
+  });
+
+  afterEach(async () => {
+    // Delete mocks from the database.
+    await CommentModel.findByIdAndDelete(oldComment.commentId);
+    await ReplyModel.findByIdAndDelete(oldReply.replyId);
+
+    // Delete cache.
+    oldComment = null;
+    oldReply = null;
+  });
+
+  it("Should update a reply", async () => {
+    const url = `/v1/comments/${oldComment.commentId}/replies/${oldReply.replyId}`;
+    const bearerToken = `bearer ${global.appToken}`;
+    const contentUpdate = "New Reply Update";
+
+    // Run test matchers to verify that the reply has not been updated in the database.
+    await ReplyModel.findById(oldReply.replyId).then((reply) => {
+      expect(reply).toBeTruthy();
+      expect(reply.content).toEqual(oldReply.content);
+    });
+
+    // Run test matchers to verify that the reply update produced the correct success response.
+    const res = await request
+      .patch(url)
+      .set("Authorization", bearerToken)
+      .send({
+        ownerId: oldReply.ownerId,
+        content: contentUpdate,
+      });
+
+    expect(res.status).toEqual(200);
+    expect(res.body.status).toEqual("success");
+    expect(res.body.data).toEqual({
+      ownerId: oldReply.ownerId,
+      content: contentUpdate,
+    });
+
+    // Run test matchers to verify that the reply has been updated in the database.
+    await ReplyModel.findById(oldReply.replyId).then((reply) => {
+      expect(reply).toBeTruthy();
+      expect(reply.content).not.toEqual(oldReply.content);
+      expect(reply.content).toEqual(contentUpdate);
+    });
+  });
+
+  it("Should return a 401 error when the authorization header's token is unauthorized", async () => {
+    const url = `/v1/comments/${oldComment.commentId}/replies/${oldReply.replyId}`;
+    const bearerToken = `bearer `;
+
+    const res = await request
+      .patch(url)
+      .set("Authorization", bearerToken)
+      .send({
+        ownerId: oldReply.ownerId,
+        content: "content",
+      });
+
+    expect(res.status).toEqual(401);
+    expect(res.body.status).toEqual("error");
+    expect(res.body.data).toEqual([]);
+  });
+
+  it("Should return a 404 error when the commentId path parameter is invalid", async () => {
+    const url = `/v1/comments/${oldComment.commentId}/replies/4edd30e86762e0fb12000003`;
+    const bearerToken = `bearer ${global.appToken}`;
+
+    const res = await request
+      .patch(url)
+      .set("Authorization", bearerToken)
+      .send({
+        ownerId: oldReply.ownerId,
+        content: "content",
+      });
+
+    expect(res.status).toEqual(404);
+    expect(res.body.status).toEqual("error");
+    expect(res.body.data).toEqual([]);
+  });
+
+  it("Should return a 422 error when the content body property is missing or invalid", async () => {
+    const url = `/v1/comments/${oldComment.commentId}/replies/${oldReply.replyId}`;
+    const bearerToken = `bearer ${global.appToken}`;
+
+    const missingRes = await request
+      .patch(url)
+      .set("Authorization", bearerToken)
+      .send({
+        ownerId: oldReply.ownerId,
+      });
+
+    expect(missingRes.status).toEqual(422);
+    expect(missingRes.body.status).toEqual("error");
+    expect(missingRes.body.data).toBeTruthy();
+
+    const invalidRes = await request
+      .patch(url)
+      .set("Authorization", bearerToken)
+      .send({
+        ownerId: oldReply.ownerId,
+        content: "",
+      });
+
+    expect(invalidRes.status).toEqual(422);
+    expect(invalidRes.body.status).toEqual("error");
+    expect(invalidRes.body.data).toBeTruthy();
+  });
+
+  it("Should return a 422 error when the ownerId body property is missing or invalid", async () => {
+    const url = `/v1/comments/${oldComment.commentId}/replies/${oldReply.replyId}`;
+    const bearerToken = `bearer ${global.appToken}`;
+
+    const missingRes = await request
+      .patch(url)
+      .set("Authorization", bearerToken)
+      .send({
+        content: "content",
+      });
+
+    expect(missingRes.status).toEqual(422);
+    expect(missingRes.body.status).toEqual("error");
+    expect(missingRes.body.data).toBeTruthy();
+
+    const invalidRes = await request
+      .patch(url)
+      .set("Authorization", bearerToken)
+      .send({
+        ownerId: 2,
+        content: "content",
+      });
+
+    expect(invalidRes.status).toEqual(422);
+    expect(invalidRes.body.status).toEqual("error");
+    expect(invalidRes.body.data).toBeTruthy();
+  });
+});

--- a/controllers/repliesController/updateSingleReply.js
+++ b/controllers/repliesController/updateSingleReply.js
@@ -45,7 +45,7 @@ const updateSingleReply = async (req, res, next) => {
     if (ownerId !== reply.ownerId) {
       return next(new CustomError(401, "Unauthorized ID"));
     }
-    await reply.updateOne(
+    await Replies.updateOne(
       { _id: replyId },
       { $set: { content: content, isEdited: true } }
     );

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -1656,13 +1656,6 @@ paths:
                     items:
                       $ref: "#/components/schemas/UpdateReply"
 
-        "400":
-          description: Bad request error
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/ErrorResponse"
-
         "401":
           description: Authentication error
           content:


### PR DESCRIPTION
**Before submitting your PR for review**

- Run `npm run lint` to find errors in code syntax/format
- Run `npm run lint:fix` to fix all auto-fixable errors in source code and auto-format with prettier
- Ensure you fix any linting errors displayed after running any of the above commands

**What does this PR do?**

Fixes #354 

This PR implements a test suite that will cover all required functionality expected from the updateSingleReply endpoint /v1/comments/{commentId}/replies/{replyId}. For each test that doesn't pass, the controller method (along with its validation schema and swagger docs if the modifications require it) will be modified to include the required functionalities so that the test passes.

**description of Task to be completed?**

- [x] test that a request returns with the correct update response and status 200
- [x] test that a request with an unauthorized token returns with correct error response and status 401
- [x] test that a request with an invalid ID returns with correct error response and status 404
- [x] test that a request with a missing "content" returns with correct error response and status 422
- [x] test that a request with a "content" of less than 1 returns with correct error response and status 422
- [x] test that a request with a missing "ownerId" returns with correct error response and status 422

**How should this be manually tested?**

- In your terminal, run `npm test`

**Any background context you want to provide?**

None

**What is the link to the issue on Github?**

[Issue #332](https://github.com/microapidev/comment-microapi/issues/332)

**Questions:**

I am having trouble implementing the query for filtering by whether or not a reply has a flag or not for the isFlagged query parameter. I am hoping that someone with better knowledge on Mongo can help with making this query possible in an efficient way.