### PR TITLE
fixes #350: getSingleOrganizationToken.test.js

### DIFF
--- a/__test__/api/organizations/getSingleOrganizationToken.test.js
+++ b/__test__/api/organizations/getSingleOrganizationToken.test.js
@@ -1,0 +1,67 @@
+const app = require("../../../server");
+const OrganizationModel = require("../../../models/organizations");
+const AdminModel = require("../../../models/admins");
+const supertest = require("supertest");
+const { hashPassword } = require("../../../utils/auth/passwordUtils");
+const request = supertest(app);
+
+let organizationInfo = {
+  name: "Justice League",
+  email: "jladmin@hotels.ng",
+  password: "jlorg2020",
+};
+
+let adminInfo = {
+  fullname: "Admin",
+  email: "admin@hotels.ng",
+  password: "jladmin2020",
+};
+
+describe("POST /organizations/token", () => {
+  let savedAdmin;
+  const url = "/v1/organizations/token";
+  beforeAll(async () => {
+    const secret = await hashPassword(organizationInfo.password);
+    const Organization = new OrganizationModel({
+      ...organizationInfo,
+      secret,
+    });
+    const password = await hashPassword(adminInfo.password);
+    let savedOrganization = await Organization.save();
+    const Admin = new AdminModel({
+      ...adminInfo,
+      password,
+      organizationId: savedOrganization._id,
+    });
+    savedAdmin = await Admin.save();
+  });
+
+  it("Should return organization token on successful login", async () => {
+    const res = await request.post(url).send({
+      email: adminInfo.email,
+      password: adminInfo.password,
+      organizationId: savedAdmin.organizationId,
+    });
+    expect(res.status).toEqual(200);
+    expect(res.body.status).toEqual("success");
+    expect(res.body.data.organizationToken).toBeTruthy();
+  });
+
+  it("Should return authentication error on failed login", async () => {
+    const res = await request.post(url).send({
+      email: adminInfo.email,
+      password: "lol wrong!",
+      organizationId: savedAdmin.organizationId,
+    });
+    expect(res.status).toEqual(401);
+    expect(res.body.status).toEqual("error");
+    expect(res.body.error).toBeTruthy();
+  });
+
+  it("Should return validation error on missing inputs", async () => {
+    const res = await request.post(url);
+    expect(res.status).toEqual(422);
+    expect(res.body.status).toEqual("error");
+    expect(res.body.error).toEqual(expect.stringContaining("input"));
+  });
+});

--- a/controllers/organizationsController/getSingleOrganizationToken.js
+++ b/controllers/organizationsController/getSingleOrganizationToken.js
@@ -22,7 +22,7 @@ const getSingleOrganizationToken = async (req, res, next) => {
 
   // if not found return error
   if (!admin) {
-    next(new CustomError(400, "Invalid email and/or password"));
+    next(new CustomError(401, "Invalid email and/or password"));
     return;
   }
 
@@ -37,7 +37,7 @@ const getSingleOrganizationToken = async (req, res, next) => {
 
   //if not password matched return error
   if (!passwordMatched) {
-    next(new CustomError(400, "Invalid email and/or password"));
+    next(new CustomError(401, "Invalid email and/or password"));
     return;
   }
 


### PR DESCRIPTION
**What does this PR do?**

Fixes #350 
Adds tests for getting organization token
Correct status code in the controller

**What is the link to the issue on Github?**

[Issue #350](https://github.com/microapidev/comment-microapi/issues/350)

**Questions:**
* In the spec, `organizationEmail` is part of the body, but `email` is being checked while validating, this caused some confusion for me, but I figured the spec was not updated.
* Also the spec specified 401 as the status code for authentication error, but 400 was being sent, I changed this to 401 because I think the spec is more correct here
* The spec also specified 201 as the status code for a successful operation, but the code is sending 200, I wasn't sure which was correct here, so I left it like that and tested for 200.