### PR TITLE
[Fix]: Link replies' controllers to application

### DIFF
--- a/controllers/repliesController/getAllReplies.js
+++ b/controllers/repliesController/getAllReplies.js
@@ -20,13 +20,14 @@ const responseHandler = require("../../utils/responseHandler");
 const getAllReplies = async (req, res, next) => {
   const { commentId } = req.params;
   const { isFlagged, ownerId } = req.query;
+  const { applicationId } = req.token;
 
   if (!ObjectId.isValid(commentId)) {
     return next(new CustomError(400, " Invalid comment Id "));
   }
   try {
     //check if such comment exists
-    const comment = await Comments.findById(commentId);
+    const comment = await Comments.findOne({ _id: commentId, applicationId });
     // If the comment does not exist,send an error msg
     if (!comment) {
       return next(new CustomError(404, " Comment not found "));

--- a/controllers/repliesController/getSingleReply.js
+++ b/controllers/repliesController/getSingleReply.js
@@ -20,6 +20,7 @@ const responseHandler = require("../../utils/responseHandler");
 
 const getSingleReply = async (req, res, next) => {
   const { commentId, replyId } = req.params;
+  const { applicationId } = req.token;
 
   if (!ObjectId.isValid(commentId)) {
     return next(new CustomError(400, " Invalid comment Id "));
@@ -29,7 +30,7 @@ const getSingleReply = async (req, res, next) => {
   }
   try {
     //check if such comment exists
-    const comment = await Comments.findById(commentId);
+    const comment = await Comments.findOne({ _id: commentId, applicationId });
     // If the comment does not exist,send an error msg
     if (!comment) {
       return next(new CustomError(404, " Comment not found "));

--- a/controllers/repliesController/getSingleReplyVotes.js
+++ b/controllers/repliesController/getSingleReplyVotes.js
@@ -21,6 +21,7 @@ const getSingleReplyVotes = async (req, res, next) => {
   try {
     const { commentId, replyId } = req.params;
     const { voteType } = req.query;
+    const { applicationId } = req.token;
 
     if (!ObjectId.isValid(commentId)) {
       return next(new CustomError(404, "Invalid ID"));
@@ -30,16 +31,19 @@ const getSingleReplyVotes = async (req, res, next) => {
       return next(new CustomError(404, "Invalid ID"));
     }
 
-    const parentComment = await Comments.findById(commentId);
-
-    // Check to see if the parent comment exists.
+    //confirm reply belongs to a comment in the same application
+    const parentComment = await Comments.findOne({
+      _id: commentId,
+      applicationId,
+    });
     if (!parentComment) {
-      return next(
+      next(
         new CustomError(
           404,
           `Comment with the ID ${commentId} does not exist or has been deleted`
         )
       );
+      return;
     }
 
     const reply = await Replies.findById(replyId);

--- a/controllers/repliesController/updateSingleReply.js
+++ b/controllers/repliesController/updateSingleReply.js
@@ -21,6 +21,7 @@ const responseHandler = require("../../utils/responseHandler");
 const updateSingleReply = async (req, res, next) => {
   const { commentId, replyId } = req.params;
   const { content, ownerId } = req.body;
+  const { applicationId } = req.token;
 
   if (!ObjectId.isValid(commentId)) {
     return next(new CustomError(422, " Invalid comment ID"));
@@ -31,10 +32,19 @@ const updateSingleReply = async (req, res, next) => {
   }
 
   try {
-    let comment = await Comments.findById(commentId);
-
-    if (!comment) {
-      return next(new CustomError(404, "Comment not found or deleted"));
+    //confirm reply belongs to a comment in the same application
+    const parentComment = await Comments.findOne({
+      _id: commentId,
+      applicationId,
+    });
+    if (!parentComment) {
+      next(
+        new CustomError(
+          404,
+          `Comment with the ID ${commentId} does not exist or has been deleted`
+        )
+      );
+      return;
     }
 
     let reply = await Replies.findById(replyId);

--- a/controllers/repliesController/updateSingleReplyDownVotes.js
+++ b/controllers/repliesController/updateSingleReplyDownVotes.js
@@ -19,12 +19,24 @@ const updateSingleReplyDownVotes = async (req, res, next) => {
   const commentId = req.params.commentId;
   const replyId = req.params.replyId;
   const ownerId = req.body.ownerId;
+  const { applicationId } = req.token;
 
   try {
-    let comment = await Comments.findById(commentId);
-    if (!comment) {
-      return next(new CustomError(404, "Comment not found or deleted"));
+    //confirm reply belongs to a comment in the same application
+    const parentComment = await Comments.findOne({
+      _id: commentId,
+      applicationId,
+    });
+    if (!parentComment) {
+      next(
+        new CustomError(
+          404,
+          `Comment with the ID ${commentId} does not exist or has been deleted`
+        )
+      );
+      return;
     }
+
     let reply = await Replies.findById(replyId);
     if (!reply) {
       return next(new CustomError(404, "Reply not found or deleted"));

--- a/controllers/repliesController/updateSingleReplyUpVotes.js
+++ b/controllers/repliesController/updateSingleReplyUpVotes.js
@@ -20,12 +20,24 @@ const updateSingleReplyUpVotes = async (req, res, next) => {
   const commentId = req.params.commentId;
   const replyId = req.params.replyId;
   const ownerId = req.body.ownerId;
+  const { applicationId } = req.token;
 
   try {
-    let comment = await Comments.findById(commentId);
-    if (!comment) {
-      return next(new CustomError(404, "Comment not found or deleted"));
+    //confirm reply belongs to a comment in the same application
+    const parentComment = await Comments.findOne({
+      _id: commentId,
+      applicationId,
+    });
+    if (!parentComment) {
+      next(
+        new CustomError(
+          404,
+          `Comment with the ID ${commentId} does not exist or has been deleted`
+        )
+      );
+      return;
     }
+
     let reply = await Replies.findById(replyId);
     if (!reply) {
       return next(new CustomError(404, "Reply not found or deleted"));

--- a/routes/replies.js
+++ b/routes/replies.js
@@ -54,7 +54,11 @@ router.patch(
   repliesController.updateSingleReplyDownVotes
 );
 
-router.patch("/:replyId/flag", repliesController.updateSingleReplyFlags);
+router.patch(
+  "/:replyId/flag",
+  validationMiddleware(validationRules.updateReplyFlagSchema),
+  repliesController.updateSingleReplyFlags
+);
 
 /**
  * DELETE routes

--- a/utils/validationRules/index.js
+++ b/utils/validationRules/index.js
@@ -13,6 +13,7 @@ const updateReplySchema = require("./replies/updateReplySchema");
 const deleteReplySchema = require("./replies/deleteReplySchema");
 const getReplyVotesSchema = require("./replies/getReplyVotesSchema");
 const updateReplyUpAndDownVoteSchema = require("./replies/updateReplyUpAndDownVoteSchema");
+const updateReplyFlagSchema = require("./replies/updateReplyFlagSchema");
 
 const createOrganizationSchema = require("./organizations/createOrganizationSchema");
 const getOrganizationTokenSchema = require("./organizations/getOrganizationTokenSchema");
@@ -52,6 +53,7 @@ module.exports = {
   deleteReplySchema,
   getReplyVotesSchema,
   updateReplyUpAndDownVoteSchema,
+  updateReplyFlagSchema,
 
   //Organization Endpoints validation schemas
   createOrganizationSchema,

--- a/utils/validationRules/replies/updateReplyFlagSchema.js
+++ b/utils/validationRules/replies/updateReplyFlagSchema.js
@@ -1,0 +1,23 @@
+const Joi = require("@hapi/joi");
+const mongoIdSchema = require("../mongoIdSchema");
+
+/**
+ * Schema validation for PATCH '/comments/{commentId}/replies/{replyId}'
+ */
+
+const updateReplyFlagSchema = {
+  headers: Joi.object({
+    authorization: Joi.string().required(),
+  }),
+
+  params: Joi.object().keys({
+    commentId: Joi.custom(mongoIdSchema, "Mongo ObjectID").required(),
+    replyId: Joi.custom(mongoIdSchema, "Mongo ObjectID").required(),
+  }),
+
+  body: Joi.object().keys({
+    ownerId: Joi.string().required(),
+  }),
+};
+
+module.exports = updateReplyFlagSchema;


### PR DESCRIPTION
**Before submitting your PR for review**

- Run `npm run lint` to find errors in code syntax/format
- Run `npm run lint:fix` to fix all auto-fixable errors in source code and auto-format with prettier
- Ensure you fix any linting errors displayed after running any of the above commands

**What does this PR do?**

Fixes #364 

Modify all replies controllers to check that a reply's parent comment belongs to the requesting application

**Description of Task to be completed?**
- Add `replyFlagSchema` validation rule and middleware
- Add condition checking that a reply's parent comment belongs to the requesting application

**How should this be manually tested?**
Attempt to get a reply belonging to a different application will result in a 404 error