### PR TITLE
[TEST] getSingleReplyVotes API Endpoint Tests

### DIFF
--- a/__test__/api/replies/getSingleReplyVotes.test.js
+++ b/__test__/api/replies/getSingleReplyVotes.test.js
@@ -25,6 +25,8 @@ describe("GET /comments/:commentId/replies/:replyid/votes", () => {
       content: "A reply from user 2",
       ownerId: "user2@email.com",
       commentId: mockedCommentDoc.id,
+      upVotes: ["voter1@gmail.com", "voter2@gmail.com"],
+      downVotes: ["voter3@gmail.com"],
     });
 
     // Save mocked comment document to the database and cache.

--- a/__test__/api/replies/getSingleReplyVotes.test.js
+++ b/__test__/api/replies/getSingleReplyVotes.test.js
@@ -111,7 +111,7 @@ describe("GET /comments/:commentId/replies/:replyid/votes", () => {
     expect(res.body.data).toEqual([]);
   });
 
-  it("Should return a 404 error when the commentId path parameter is invalid", async () => {
+  it("Should return a 404 error when the commentId  does not exist in database", async () => {
     const invalidCommentUrl = `/v1/comments/4edd30e86762e0fb12000003/replies/${reply1.replyId}/votes`;
     const bearerToken = `bearer ${global.appToken}`;
 
@@ -124,7 +124,7 @@ describe("GET /comments/:commentId/replies/:replyid/votes", () => {
     expect(invalidCommentRes.body.data).toEqual([]);
   });
 
-  it("Should return a 404 error when the replyId path parameter is invalid", async () => {
+  it("Should return a 404 error when the replyId does not exist in database", async () => {
     const invalidReplyUrl = `/v1/comments/${comment.commentId}/replies/4edd30e86762e0fb12000003/votes`;
     const bearerToken = `bearer ${global.appToken}`;
 

--- a/__test__/api/replies/getSingleReplyVotes.test.js
+++ b/__test__/api/replies/getSingleReplyVotes.test.js
@@ -1,0 +1,139 @@
+const app = require("../../../server");
+const CommentModel = require("../../../models/comments");
+const ReplyModel = require("../../../models/replies");
+const commentHandler = require("../../../utils/commentHandler");
+const replyHandler = require("../../../utils/replyHandler");
+// const mongoose = require("mongoose");
+const supertest = require("supertest");
+const request = supertest(app);
+
+let comment, reply1;
+let allVotes;
+describe("GET /comments/:commentId/replies/:replyid/votes", () => {
+  beforeEach(async () => {
+    // Mock a comment document
+    const mockedCommentDoc = new CommentModel({
+      content: "A comment from user 1",
+      ownerId: "user1@email.com",
+      origin: "123123",
+      refId: 2,
+      applicationId: global.application._id,
+    });
+
+    // Mock a reply document.
+    const mockedReply1Doc = new ReplyModel({
+      content: "A reply from user 2",
+      ownerId: "user2@email.com",
+      commentId: mockedCommentDoc.id,
+    });
+
+    // Save mocked comment document to the database and cache.
+    const savedComment = await mockedCommentDoc.save();
+
+    // Save mocked replies document to the database.
+    const savedReply1 = await mockedReply1Doc.save();
+
+    // Add replies to the mocked comment.
+    await CommentModel.findByIdAndUpdate(savedComment.id, {
+      $push: {
+        replies: { $each: [savedReply1.id] },
+      },
+    });
+
+    // Cache response objects
+    comment = commentHandler(savedComment);
+    reply1 = replyHandler(savedReply1);
+  });
+
+  afterEach(async () => {
+    //delete mocks from the db
+    await CommentModel.findByIdAndDelete(comment.commentId);
+    await ReplyModel.findByIdAndDelete(reply1.replyId);
+
+    //delete cache
+    comment = null;
+    reply1 = null;
+  });
+
+  it("Should get all votes of a reply", async () => {
+    const url = `/v1/comments/${comment.commentId}/replies/${reply1.replyId}/votes`;
+    const bearerToken = `bearer ${global.appToken}`;
+
+    const getAllVotesRequest = request
+      .get(url)
+      .set("Authorization", bearerToken);
+
+    return getAllVotesRequest.then((res) => {
+      expect(res.status).toBe(200);
+      expect(res.body.data.commentId).toEqual(comment.commentId);
+      expect(res.body.data.votes).toEqual(allVotes);
+    });
+  });
+
+  it("Should get all upvotes of a reply", async () => {
+    const url = `/v1/comments/${comment.commentId}/replies/${reply1.replyId}/votes?voteType=upvote`;
+    const bearerToken = `bearer ${global.appToken}`;
+
+    const getAllVotesRequest = request
+      .get(url)
+      .set("Authorization", bearerToken);
+
+    return getAllVotesRequest.then((res) => {
+      expect(res.status).toBe(200);
+      expect(res.body.data.commentId).toEqual(comment.commentId);
+      expect(res.body.data.votes).toEqual(comment.upVotes);
+    });
+  });
+
+  it("Should get all downvotes of a reply", async () => {
+    const url = `/v1/comments/${comment.commentId}/replies/${reply1.replyId}/votes?voteType=downvote`;
+    const bearerToken = `bearer ${global.appToken}`;
+
+    const getAllVotesRequest = request
+      .get(url)
+      .set("Authorization", bearerToken);
+
+    return getAllVotesRequest.then((res) => {
+      expect(res.status).toBe(200);
+      expect(res.body.data.commentId).toEqual(comment.commentId);
+      expect(res.body.data.votes).toEqual(comment.downVotes);
+    });
+  });
+
+  it("Should return a 401 error when the authorization header's token is unauthorized", async () => {
+    const url = `/v1/comments/${comment.commentId}/replies/${reply1.replyId}/votes`;
+    const bearerToken = `bearer `;
+
+    const res = await request.get(url).set("Authorization", bearerToken);
+
+    expect(res.status).toEqual(401);
+    expect(res.body.status).toEqual("error");
+    expect(res.body.data).toEqual([]);
+  });
+
+  it("Should return a 404 error when the commentId path parameter is invalid", async () => {
+    const invalidCommentUrl = `/v1/comments/4edd30e86762e0fb12000003/replies/${reply1.replyId}/votes`;
+    const bearerToken = `bearer ${global.appToken}`;
+
+    const invalidCommentRes = await request
+      .get(invalidCommentUrl)
+      .set("Authorization", bearerToken);
+
+    expect(invalidCommentRes.status).toEqual(404);
+    expect(invalidCommentRes.body.status).toEqual("error");
+    expect(invalidCommentRes.body.data).toEqual([]);
+  });
+
+  it("Should return a 404 error when the replyId path parameter is invalid", async () => {
+    const invalidReplyUrl = `/v1/comments/${comment.commentId}/replies/4edd30e86762e0fb12000003/votes`;
+    const bearerToken = `bearer ${global.appToken}`;
+
+    const invalidReplyRes = await request
+      .patch(invalidReplyUrl)
+      .set("Authorization", bearerToken);
+
+    expect(invalidReplyRes.status).toEqual(404);
+    expect(invalidReplyRes.body.status).toEqual("error");
+    expect(invalidReplyRes.body.data).toEqual([]);
+  });
+});

--- a/__test__/api/replies/updateSingleReply.test.js
+++ b/__test__/api/replies/updateSingleReply.test.js
@@ -110,9 +110,8 @@ describe("PATCH /comments/:commentId/replies/:replyId", () => {
     expect(res.body.data).toEqual([]);
   });
 
-  it("Should return a 404 error when the commentId or replyId path parameter is invalid", async () => {
+  it("Should return a 404 error when the commentId path parameter is invalid", async () => {
     const invalidCommentUrl = `/v1/comments/4edd30e86762e0fb12000003/replies/${oldReply.replyId}`;
-    const invalidReplyUrl = `/v1/comments/${oldComment.commentId}/replies/4edd30e86762e0fb12000003`;
     const bearerToken = `bearer ${global.appToken}`;
 
     const invalidCommentRes = await request
@@ -126,6 +125,11 @@ describe("PATCH /comments/:commentId/replies/:replyId", () => {
     expect(invalidCommentRes.status).toEqual(404);
     expect(invalidCommentRes.body.status).toEqual("error");
     expect(invalidCommentRes.body.data).toEqual([]);
+  });
+
+  it("Should return a 404 error when the commentId path parameter is invalid", async () => {
+    const invalidReplyUrl = `/v1/comments/${oldComment.commentId}/replies/4edd30e86762e0fb12000003`;
+    const bearerToken = `bearer ${global.appToken}`;
 
     const invalidReplyRes = await request
       .patch(invalidReplyUrl)

--- a/__test__/api/replies/updateSingleReply.test.js
+++ b/__test__/api/replies/updateSingleReply.test.js
@@ -127,7 +127,7 @@ describe("PATCH /comments/:commentId/replies/:replyId", () => {
     expect(invalidCommentRes.body.data).toEqual([]);
   });
 
-  it("Should return a 404 error when the commentId path parameter is invalid", async () => {
+  it("Should return a 404 error when the replyId path parameter is invalid", async () => {
     const invalidReplyUrl = `/v1/comments/${oldComment.commentId}/replies/4edd30e86762e0fb12000003`;
     const bearerToken = `bearer ${global.appToken}`;
 

--- a/utils/swaggerSpec.js
+++ b/utils/swaggerSpec.js
@@ -20,7 +20,7 @@ const swaggerDefinition = {
     description:
       "### Overview" +
       "\n\n" +
-      "The API gives the developer access to built-in functionalities for when they want to " +
+      "The Comment API gives the developer access to built-in functionalities for when they want to " +
       "implement comments and replies within their own application." +
       "\n\n" +
       "Basic functionalities are available for creation, update, and deletion of " +


### PR DESCRIPTION
**Before submitting your PR for review**

- Run `npm run lint` to find errors in code syntax/format
- Run `npm run lint:fix` to fix all auto-fixable errors in source code and auto-format with prettier
- Ensure you fix any linting errors displayed after running any of the above commands

**What does this PR do?**

Fixes #403 

This PR implements a test suite that will cover all required functionality expected from the getAllReplies endpoint /v1/comments/{commentId}/replies. For each test that doesn't pass, the controller method (along with its validation schema and swagger docs if the modifications require it) will be modified to include the required functionalities so that the test passes.

**description of Task to be completed?**

- [x] test that a request returns with the correct update response and status 200
- [x] test that a request with an unauthorized token returns with correct error response and status 401
- [x] test that a request with an invalid ID returns with correct error response and status 404
- [x] test that a request with an invalid "voteType" query parameter returns with correct error response and status 422

**How should this be manually tested?**

- In your terminal, run `npm test`

**Any background context you want to provide?**

None

**What is the link to the issue on Github?**

[Issue #403](https://github.com/microapidev/comment-microapi/issues/403)

**Questions:**

None