### PR TITLE
[feature]: Create microservice admins - POST /msadmins/create

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -4,6 +4,8 @@ APP_SECRET=app_secret
 ORG_SECRET=org_secret
 SYSTEM_SECRET=system_Dsecret
 DISABLE_AUTH=true
+SUPER_ADMIN_EMAIL=admin@someemail.com
+SUPER_ADMIN_PASSWORD=somepassword
 
 TAG=1.0.0
 DOCKER_MONGO=false

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ env:
   global:
     - APP_SECRET=app secret
     - ORG_SECRET=org secret
-    - JWT_SECRET=system secret
+    - SYSTEM_SECRET=system secret
     - DISABLE_AUTH=true
 deploy:
   provider: heroku

--- a/__test__/api/msadmins/createSingleMsAdmin.test.js
+++ b/__test__/api/msadmins/createSingleMsAdmin.test.js
@@ -1,0 +1,80 @@
+const app = require("../../../server");
+const supertest = require("supertest");
+const AdminModel = require("../../../models/admins");
+
+const request = supertest(app);
+
+describe("POST /v1/msadmins/create", () => {
+  let adminInfo = {
+    fullname: "Test Admin",
+    email: "testadmin@hotels.ng",
+    password: "password",
+  };
+  let admin2Info = {
+    fullname: "Test Admin",
+    email: "testadmin2@hotels.ng",
+    password: "password",
+    role: "superadmin",
+  };
+  let url = "/v1/msadmins/create";
+
+  it("creates an admin with default role 'admin'", async () => {
+    const res = await request
+      .post(url)
+      .set("Authorization", `bearer ${global.superSysToken}`)
+      .send(adminInfo);
+
+    expect(res.status).toBe(201);
+    expect(res.body.status).toEqual("success");
+    expect(res.body.data.msAdminId).toBeTruthy();
+
+    const savedAdmin = await AdminModel.findById(res.body.data.msAdminId);
+    expect(savedAdmin.fullname).toEqual(adminInfo.fullname);
+    expect(savedAdmin.role).toEqual("admin");
+  });
+
+  it("rejects request by non-super admin", async () => {
+    const res = await request
+      .post(url)
+      .set("Authorization", `bearer ${global.sysToken}`)
+      .send(adminInfo);
+
+    expect(res.status).toBe(401);
+    expect(res.body.status).toEqual("error");
+    expect(res.body.error).toBeTruthy();
+  });
+
+  it("creates an admin with default role 'superadmin'", async () => {
+    const res = await request
+      .post(url)
+      .set("Authorization", `bearer ${global.superSysToken}`)
+      .send(admin2Info);
+
+    expect(res.status).toBe(201);
+    expect(res.body.status).toEqual("success");
+    expect(res.body.data.msAdminId).toBeTruthy();
+
+    const savedAdmin = await AdminModel.findById(res.body.data.msAdminId);
+    expect(savedAdmin.fullname).toEqual(adminInfo.fullname);
+    expect(savedAdmin.email).toEqual(adminInfo.email);
+    expect(savedAdmin.role).toEqual("superadmin");
+  });
+
+  it("returns 401 for unauthorized user", async () => {
+    const res = await request.post(url).send(adminInfo);
+
+    expect(res.status).toBe(401);
+    expect(res.body.status).toEqual("error");
+    expect(res.body.error).toBeTruthy();
+  });
+
+  it("returns 422 for invalid input", async () => {
+    const res = await request
+      .post(url)
+      .set("Authorization", `bearer ${global.superSysToken}`);
+
+    expect(res.status).toBe(422);
+    expect(res.body.status).toEqual("error");
+    expect(res.body.error).toBeTruthy();
+  });
+});

--- a/__test__/api/msadmins/createSingleMsAdmin.test.js
+++ b/__test__/api/msadmins/createSingleMsAdmin.test.js
@@ -1,6 +1,6 @@
 const app = require("../../../server");
 const supertest = require("supertest");
-const AdminModel = require("../../../models/admins");
+const MsAdminModel = require("../../../models/msadmins");
 
 const request = supertest(app);
 
@@ -28,7 +28,7 @@ describe("POST /v1/msadmins/create", () => {
     expect(res.body.status).toEqual("success");
     expect(res.body.data.msAdminId).toBeTruthy();
 
-    const savedAdmin = await AdminModel.findById(res.body.data.msAdminId);
+    const savedAdmin = await MsAdminModel.findById(res.body.data.msAdminId);
     expect(savedAdmin.fullname).toEqual(adminInfo.fullname);
     expect(savedAdmin.role).toEqual("admin");
   });
@@ -54,9 +54,9 @@ describe("POST /v1/msadmins/create", () => {
     expect(res.body.status).toEqual("success");
     expect(res.body.data.msAdminId).toBeTruthy();
 
-    const savedAdmin = await AdminModel.findById(res.body.data.msAdminId);
-    expect(savedAdmin.fullname).toEqual(adminInfo.fullname);
-    expect(savedAdmin.email).toEqual(adminInfo.email);
+    const savedAdmin = await MsAdminModel.findById(res.body.data.msAdminId);
+    expect(savedAdmin.fullname).toEqual(admin2Info.fullname);
+    expect(savedAdmin.email).toEqual(admin2Info.email);
     expect(savedAdmin.role).toEqual("superadmin");
   });
 

--- a/__test__/config/setup.js
+++ b/__test__/config/setup.js
@@ -21,7 +21,7 @@ beforeAll(async () => {
   const date = Date.now();
 
   //create default super sysadmin
-  process.env.SUPER_ADMIN_EMAIL = "default@email.com";
+  process.env.SUPER_ADMIN_EMAIL = `default${date}@email.com`;
   process.env.SUPER_ADMIN_PASSWORD = "password";
 
   const msSuperAdminId = await createDefaultAdmin();
@@ -29,7 +29,7 @@ beforeAll(async () => {
   //create regular sysadmin
   const msAdmin = new MsAdmin({
     fullname: "Test Admin",
-    email: "regularadmin@hotels.ng",
+    email: `regularadmin${date}@hotels.ng`,
     password: "password",
   });
 

--- a/__test__/utils/auth/msadmin.test.js
+++ b/__test__/utils/auth/msadmin.test.js
@@ -1,0 +1,56 @@
+const { createDefaultAdmin } = require("../../../utils/auth/msadmin");
+const MsAdmin = require("../../../models/msadmins");
+
+describe("MsAdmin auth utils", () => {
+  describe("createDefaultAdmin", () => {
+    beforeEach(async () => {
+      //empty collection each time to avoid clash with global setup
+      await MsAdmin.deleteMany({});
+    });
+
+    it("should throw error if SUPER_ADMIN_EMAIL not found", async () => {
+      process.env.SUPER_ADMIN_PASSWORD = "password";
+      process.env.SUPER_ADMIN_EMAIL = "";
+      await expect(createDefaultAdmin()).rejects.toThrow();
+    });
+
+    it("should throw error if SUPER_ADMIN_PASSWORD not found", async () => {
+      process.env.SUPER_ADMIN_EMAIL = "test@email.com";
+      process.env.SUPER_ADMIN_PASSWORD = "";
+      await expect(createDefaultAdmin()).rejects.toThrow();
+    });
+
+    it("should create default admin", async () => {
+      process.env.SUPER_ADMIN_EMAIL = "test@email.com";
+      process.env.SUPER_ADMIN_PASSWORD = "password";
+      //hacky I know  but can refactor to check valid mongo object ID later
+      await expect(createDefaultAdmin()).resolves.toBeTruthy();
+
+      const msAdmin = await MsAdmin.findOne({
+        sysdefined: true,
+        role: "superadmin",
+      });
+      // check DB
+      expect(msAdmin.sysdefined).toBe(true);
+    });
+
+    it("should return if default account already created", async () => {
+      process.env.SUPER_ADMIN_EMAIL = "test@email.com";
+      process.env.SUPER_ADMIN_PASSWORD = "password";
+
+      //hacky I know  but can refactor to check valid mongo object ID later
+      await expect(createDefaultAdmin()).resolves.toBeTruthy();
+
+      const msAdmin = await MsAdmin.findOne({
+        sysdefined: true,
+        role: "superadmin",
+      });
+      // check DB
+      expect(msAdmin.sysdefined).toBe(true);
+
+      //try to create again
+      //hacky I know  but can refactor to check valid mongo object ID later
+      await expect(createDefaultAdmin()).resolves.toBeTruthy();
+    });
+  });
+});

--- a/bin/www.js
+++ b/bin/www.js
@@ -5,6 +5,7 @@
 var app = require("../server");
 var debug = require("debug")("fblog:server");
 var http = require("http");
+const { createDefaultAdmin } = require("../utils/auth/msadmin");
 
 /**
  * Module to allow usage of process.env
@@ -16,9 +17,13 @@ console.log("\n \t Attempting to connect to database...");
 
 //connect to mongodb
 const database = require("../db/database");
-database.connect();
-
-console.log("\n \t Database connected successfully");
+database.connect().then(() => {
+  console.log("\n \t Database connected successfully");
+  createDefaultAdmin().catch((error) => {
+    console.log(`\n \t ${error.message}`);
+    process.exit(1);
+  });
+});
 
 /**
  * Get port from environment and store in Express.

--- a/controllers/msAdminsController/createSingleMsAdmin.js
+++ b/controllers/msAdminsController/createSingleMsAdmin.js
@@ -1,0 +1,70 @@
+const MsAdmin = require("../../models/msadmins");
+const CustomError = require("../../utils/customError");
+const responseHandler = require("../../utils/responseHandler");
+const { hashPassword } = require("../../utils/auth/passwordUtils");
+
+/**
+ * @author David Okanlawon
+ *
+ * Creates a single admin.
+ *
+ * @param {*} req - The request object
+ * @param {*} res - The response object
+ * @param {*} next - The function executed to call the next middleware
+ */
+const createSingleAdmin = async (req, res, next) => {
+  //get arguments
+  const { fullname, email, password, role } = req.body;
+  const { role: adminRole } = req.token;
+
+  //check if admin account is valid and exists in organization
+  if (adminRole !== "superadmin") {
+    next(
+      new CustomError(401, "You are not authorized to access this resource")
+    );
+    return;
+  }
+
+  //---- TO-DO password should prolly be system generated for new acccounts -----
+  //hash password
+  let hashedPassword;
+  try {
+    hashedPassword = await hashPassword(password);
+  } catch (error) {
+    next(new CustomError(400, "A password processing error occured"));
+  }
+
+  //save new admin in DB
+  let newAdmin;
+  try {
+    newAdmin = new MsAdmin({
+      fullname: fullname,
+      email: email,
+      password: hashedPassword,
+      role: role,
+    });
+
+    await newAdmin.save();
+  } catch (error) {
+    const errorType =
+      error.code === 11000 ? ": admin account already exists" : "";
+
+    next(
+      new CustomError(
+        400,
+        "An error occured creating admin account" + errorType
+      )
+    );
+    return;
+  }
+
+  //return new adminId
+  return responseHandler(
+    res,
+    201,
+    { msAdminId: newAdmin._id },
+    "Admin account created successfully"
+  );
+};
+
+module.exports = createSingleAdmin;

--- a/controllers/msAdminsController/index.js
+++ b/controllers/msAdminsController/index.js
@@ -1,0 +1,6 @@
+//POST CONTROLLERS
+const createSingleMsAdmin = require("./createSingleMsAdmin");
+
+module.exports = {
+  createSingleMsAdmin,
+};

--- a/middleware/auth.js
+++ b/middleware/auth.js
@@ -16,3 +16,10 @@ exports.orgAuthMW = jwtMW({
   algorithms: ["HS256"],
   credentialsRequired: credsRequired,
 });
+
+exports.sysAuthMW = jwtMW({
+  secret: Buffer.from(process.env.SYSTEM_SECRET, "base64"),
+  requestProperty: "token",
+  algorithms: ["HS256"],
+  credentialsRequired: credsRequired,
+});

--- a/routes/msadmins.js
+++ b/routes/msadmins.js
@@ -1,0 +1,34 @@
+const express = require("express");
+const { sysAuthMW } = require("../middleware/auth");
+const msAdminsCtrl = require("../controllers/msAdminsController");
+const validMW = require("../middleware/validation");
+const validationRules = require("../utils/validationRules");
+
+const router = express.Router();
+
+//apply middleware at top of chain
+router.use(sysAuthMW);
+
+/**
+ * POST routes
+ */
+
+router.post(
+  "/create",
+  validMW(validationRules.createSingleMsAdminSchema),
+  msAdminsCtrl.createSingleMsAdmin
+);
+
+/**
+ * GET routes
+ */
+
+/**
+ * PATCH routes
+ */
+
+/**
+ * DELETE routes
+ */
+
+module.exports = router;

--- a/server.js
+++ b/server.js
@@ -5,6 +5,7 @@ const organizationsRoutes = require("./routes/organizations");
 const applicationsRoutes = require("./routes/applications");
 const documentationRoutes = require("./routes/documentation");
 const adminsRoutes = require("./routes/admins");
+const msAdminsRoutes = require("./routes/msadmins");
 const CustomError = require("./utils/customError");
 const errorHandler = require("./utils/errorhandler");
 
@@ -21,6 +22,7 @@ app.use("/v1/comments", commentRoutes);
 app.use("/v1/organizations", organizationsRoutes);
 app.use("/v1/applications", applicationsRoutes);
 app.use("/v1/admins", adminsRoutes);
+app.use("/v1/msadmins", msAdminsRoutes);
 app.use(["/v1", "/"], documentationRoutes);
 
 // Invalid route error handler

--- a/utils/auth/msadmin.js
+++ b/utils/auth/msadmin.js
@@ -1,0 +1,64 @@
+const MsAdmin = require("../../models/msadmins");
+const { hashPassword } = require("./passwordUtils");
+
+//create default super-admin if not exists
+exports.createDefaultAdmin = async () => {
+  //search for default admin user
+  try {
+    const msAdmin = await MsAdmin.findOne({
+      sysdefined: true,
+      role: "superadmin",
+    });
+
+    if (msAdmin) {
+      console.log("\n \t Minimal account found");
+      return msAdmin.id;
+    }
+  } catch (error) {
+    throw new Error(`Error getting minimal account: ${error.message}`);
+  }
+
+  try {
+    //if not found read in SUPER_ADMIN_PASSWORD, SUPER_ADMIN_EMAIL from env
+    console.log("\n \t Minimal account not found ... creating");
+
+    //check email
+    const superAdminEmail = process.env.SUPER_ADMIN_EMAIL;
+
+    //if no password found exit requesting the variable
+    if (!superAdminEmail) {
+      throw new Error(
+        "Please specify a SUPER_ADMIN_EMAIL environment variable. Exiting ..."
+      );
+    }
+
+    //check password
+    const superAdminPassword = process.env.SUPER_ADMIN_PASSWORD;
+
+    //if no password found exit requesting the variable
+    if (!superAdminPassword) {
+      throw new Error(
+        "Please specify a SUPER_ADMIN_PASSWORD environment variable. Exiting ..."
+      );
+    }
+
+    //hash the password
+    const hashedPassword = await hashPassword(superAdminPassword);
+
+    //create a default admin account and log on screen
+    const newAdmin = new MsAdmin({
+      fullname: "Default system admin account",
+      password: hashedPassword,
+      email: superAdminEmail, //TODO: we need a custom email validator on schema
+      sysdefined: true,
+      role: "superadmin",
+    });
+
+    await newAdmin.save();
+    console.log("\n \t Minimal account created successfully");
+    return newAdmin.id;
+  } catch (error) {
+    console.log(error.message);
+    throw new Error(`An error occured creating account ${error.message}`);
+  }
+};

--- a/utils/auth/msadmin.js
+++ b/utils/auth/msadmin.js
@@ -56,6 +56,8 @@ exports.createDefaultAdmin = async () => {
 
     await newAdmin.save();
     console.log("\n \t Minimal account created successfully");
+
+    //TO-DO wipe details from .env file after successful creation
     return newAdmin.id;
   } catch (error) {
     console.log(error.message);

--- a/utils/auth/tokenGenerator.js
+++ b/utils/auth/tokenGenerator.js
@@ -99,10 +99,8 @@ const getSysToken = async (msAdminId) => {
     throw new CustomError(400, "Invalid msAdmin ID");
   }
 
-  // confirm adminId belongs to organization
-  const msAdmin = await MsAdmin.find({
-    _id: msAdminId,
-  });
+  // confirm adminId exists
+  const msAdmin = await MsAdmin.findById(msAdminId);
   if (!msAdmin) {
     throw new CustomError(
       401,

--- a/utils/validationRules/index.js
+++ b/utils/validationRules/index.js
@@ -34,6 +34,8 @@ const updateSingleAdminSchema = require("./admins/updateSingleAdminSchema");
 const changeAdminPasswordSchema = require("./admins/changeAdminPasswordSchema");
 const adminDeleteCommentSchema = require("./admins/adminDeleteCommentSchema");
 
+const createSingleMsAdminSchema = require("./msadmins/createSingleMsAdminSchema");
+
 /**
  * Object containing schema validations for the endpoints.
  */
@@ -78,4 +80,7 @@ module.exports = {
   getSingleAdminSchema,
   updateSingleAdminSchema,
   adminDeleteCommentSchema,
+
+  // MsAdmins Endpoints validation schemas
+  createSingleMsAdminSchema,
 };

--- a/utils/validationRules/msadmins/createSingleMsAdminSchema.js
+++ b/utils/validationRules/msadmins/createSingleMsAdminSchema.js
@@ -1,10 +1,9 @@
 const Joi = require("@hapi/joi");
-const mongoIdSchema = require("../mongoIdSchema");
 
 /**
  * Schema validation for POST '/admins'
  */
-const createSingleAdminSchema = {
+const createApplicationSchema = {
   headers: Joi.object({
     authorization: Joi.string().required(),
   }),
@@ -13,8 +12,8 @@ const createSingleAdminSchema = {
     fullname: Joi.string().required(),
     email: Joi.string().email().required(),
     password: Joi.string().min(8).required(),
-    organizationId: Joi.custom(mongoIdSchema, "mongo ObjectId").required(),
+    role: Joi.string(),
   }),
 };
 
-module.exports = createSingleAdminSchema;
+module.exports = createApplicationSchema;


### PR DESCRIPTION
**Before submitting your PR for review**

- Run `npm run lint` to find errors in code syntax/format
- Run `npm run lint:fix` to fix all auto-fixable errors in source code and auto-format with prettier
- Ensure you fix any linting errors displayed after running any of the above commands

**What does this PR do?**

Fixes #428 

Create endpoint for creating microservice admins and supporting utilities

**Description of Task to be completed?**

- Create functionality to create a default super admin for microservice when none is found from ENV variables
- Write tests for creating microservice admins endpoint
- Create authentication middleware for microservice administration routes
- Create controller for creating microservice admins
- Add validation rules and middleware
- Attach controller to route

**How should this be manually tested?**

- Send POST request to `/v1/msadmins/create` with the sample body and valid superAdmin system token
```
{
  "fullname": "admin user",
  "email": "email@domain.com",
  "password": "password",
  "role": "role"
}
```

**Any background context you want to provide?**
- Only microservice superadmins can create other microservice admins
- New `ENV` variables introduced SUPER_ADMIN_EMAIL, SUPER_ADMIN_PASSWORD to use for auto-creating super-admin if not found. System will halt on startup if no system-defined, super-admin is found. So it is imperative to have these settings on a new DB.
- New variable samples have been included in `sample.env` file
