### PR TITLE
[feature]: setup pagination on `GET /comments & GET .../replies` endpoints

### DIFF
--- a/__test__/api/comments/getAllComments.test.js
+++ b/__test__/api/comments/getAllComments.test.js
@@ -155,6 +155,78 @@ describe("GET /comments", () => {
     });
   });
 
+  it("Should get all comments with set limit", () => {
+    const url = `/v1/comments`;
+    const bearerToken = `bearer ${global.appToken}`;
+
+    const getAllCommentsRequest = request
+      .get(url)
+      .query({ limit: 2 })
+      .set("Authorization", bearerToken);
+
+    const expectedValue = [comment1, comment2];
+
+    return getAllCommentsRequest.then((res) => {
+      expect(res.status).toEqual(200);
+      expect(res.body.status).toEqual("success");
+      expect(res.body.data).toEqual(expectedValue);
+    });
+  });
+
+  it("Should get all comments with set offset", () => {
+    const url = `/v1/comments`;
+    const bearerToken = `bearer ${global.appToken}`;
+
+    const getAllCommentsRequest = request
+      .get(url)
+      .query({ offset: 0 })
+      .set("Authorization", bearerToken);
+
+    const expectedValue = [comment1, comment2];
+
+    return getAllCommentsRequest.then((res) => {
+      expect(res.status).toEqual(200);
+      expect(res.body.status).toEqual("success");
+      expect(res.body.data).toEqual(expectedValue);
+    });
+  });
+
+  it("Should get all comments with set sort type", () => {
+    const url = `/v1/comments`;
+    const bearerToken = `bearer ${global.appToken}`;
+
+    const getAllCommentsRequest = request
+      .get(url)
+      .query({ sort: "asc" })
+      .set("Authorization", bearerToken);
+
+    const expectedValue = [comment1, comment2];
+
+    return getAllCommentsRequest.then((res) => {
+      expect(res.status).toEqual(200);
+      expect(res.body.status).toEqual("success");
+      expect(res.body.data).toEqual(expectedValue);
+    });
+  });
+
+  it("Should get all comments with all pagination params set", () => {
+    const url = `/v1/comments`;
+    const bearerToken = `bearer ${global.appToken}`;
+
+    const getAllCommentsRequest = request
+      .get(url)
+      .query({ limit: 2, offset: 0, sort: "asc" })
+      .set("Authorization", bearerToken);
+
+    const expectedValue = [comment1, comment2];
+
+    return getAllCommentsRequest.then((res) => {
+      expect(res.status).toEqual(200);
+      expect(res.body.status).toEqual("success");
+      expect(res.body.data).toEqual(expectedValue);
+    });
+  });
+
   it("Should return a 401 error when authorization token is unauthorized", () => {
     const url = `/v1/comments`;
     const bearerToken = `bearer `;

--- a/__test__/api/comments/getAllComments.test.js
+++ b/__test__/api/comments/getAllComments.test.js
@@ -182,7 +182,7 @@ describe("GET /comments", () => {
       .query({ page: 1 })
       .set("Authorization", bearerToken);
 
-    const expectedValue = [comment1,comment2];
+    const expectedValue = [comment1, comment2];
 
     return getAllCommentsRequest.then((res) => {
       expect(res.status).toEqual(200);

--- a/__test__/api/comments/getAllComments.test.js
+++ b/__test__/api/comments/getAllComments.test.js
@@ -61,7 +61,7 @@ describe("GET /comments", () => {
     return getAllCommentsRequest.then((res) => {
       expect(res.status).toEqual(200);
       expect(res.body.status).toEqual("success");
-      expect(res.body.data).toEqual(expectedValue);
+      expect(res.body.data.records).toEqual(expectedValue);
     });
   });
 
@@ -79,7 +79,7 @@ describe("GET /comments", () => {
     return getAllCommentsRequest.then((res) => {
       expect(res.status).toEqual(200);
       expect(res.body.status).toEqual("success");
-      expect(res.body.data).toEqual(expectedValue);
+      expect(res.body.data.records).toEqual(expectedValue);
     });
   });
 
@@ -97,7 +97,7 @@ describe("GET /comments", () => {
     return getAllCommentsRequest.then((res) => {
       expect(res.status).toEqual(200);
       expect(res.body.status).toEqual("success");
-      expect(res.body.data).toEqual(expectedValue);
+      expect(res.body.data.records).toEqual(expectedValue);
     });
   });
 
@@ -115,7 +115,7 @@ describe("GET /comments", () => {
     return getAllCommentsRequest.then((res) => {
       expect(res.status).toEqual(200);
       expect(res.body.status).toEqual("success");
-      expect(res.body.data).toEqual(expectedValue);
+      expect(res.body.data.records).toEqual(expectedValue);
     });
   });
 
@@ -133,7 +133,7 @@ describe("GET /comments", () => {
     return getAllCommentsRequest.then((res) => {
       expect(res.status).toEqual(200);
       expect(res.body.status).toEqual("success");
-      expect(res.body.data).toEqual(expectedValue);
+      expect(res.body.data.records).toEqual(expectedValue);
     });
   });
 
@@ -151,7 +151,7 @@ describe("GET /comments", () => {
     return getAllCommentsRequest.then((res) => {
       expect(res.status).toEqual(200);
       expect(res.body.status).toEqual("success");
-      expect(res.body.data).toEqual(expectedValue);
+      expect(res.body.data.records).toEqual(expectedValue);
     });
   });
 
@@ -161,33 +161,33 @@ describe("GET /comments", () => {
 
     const getAllCommentsRequest = request
       .get(url)
-      .query({ limit: 2 })
+      .query({ limit: 1 })
       .set("Authorization", bearerToken);
 
-    const expectedValue = [comment1, comment2];
+    const expectedValue = [comment1];
 
     return getAllCommentsRequest.then((res) => {
       expect(res.status).toEqual(200);
       expect(res.body.status).toEqual("success");
-      expect(res.body.data).toEqual(expectedValue);
+      expect(res.body.data.records).toEqual(expectedValue);
     });
   });
 
-  it("Should get all comments with set offset", () => {
+  it("Should get all comments with set page", () => {
     const url = `/v1/comments`;
     const bearerToken = `bearer ${global.appToken}`;
 
     const getAllCommentsRequest = request
       .get(url)
-      .query({ offset: 0 })
+      .query({ page: 1 })
       .set("Authorization", bearerToken);
 
-    const expectedValue = [comment1, comment2];
+    const expectedValue = [comment1,comment2];
 
     return getAllCommentsRequest.then((res) => {
       expect(res.status).toEqual(200);
       expect(res.body.status).toEqual("success");
-      expect(res.body.data).toEqual(expectedValue);
+      expect(res.body.data.records).toEqual(expectedValue);
     });
   });
 
@@ -205,7 +205,7 @@ describe("GET /comments", () => {
     return getAllCommentsRequest.then((res) => {
       expect(res.status).toEqual(200);
       expect(res.body.status).toEqual("success");
-      expect(res.body.data).toEqual(expectedValue);
+      expect(res.body.data.records).toEqual(expectedValue);
     });
   });
 
@@ -215,7 +215,7 @@ describe("GET /comments", () => {
 
     const getAllCommentsRequest = request
       .get(url)
-      .query({ limit: 2, offset: 0, sort: "asc" })
+      .query({ limit: 2, page: 1, sort: "asc" })
       .set("Authorization", bearerToken);
 
     const expectedValue = [comment1, comment2];
@@ -223,7 +223,7 @@ describe("GET /comments", () => {
     return getAllCommentsRequest.then((res) => {
       expect(res.status).toEqual(200);
       expect(res.body.status).toEqual("success");
-      expect(res.body.data).toEqual(expectedValue);
+      expect(res.body.data.records).toEqual(expectedValue);
     });
   });
 

--- a/__test__/api/organizations/deleteSingleOrganization.js
+++ b/__test__/api/organizations/deleteSingleOrganization.js
@@ -8,12 +8,12 @@ describe("Delete /organizations/:organizationId", () => {
   let organization;
   beforeEach(async () => {
     organization = new OrganizationModel({
-        organizationName: 'HNG SDK',
-        organizationEmail: `org@hngi7.com`,
-        secret: 'shhhh!',
-        adminName: 'ORG_MANAGER',
-        adminEmail: `org@comments.com`,
-        adminPassword: 'thisisapassword',
+      organizationName: "HNG SDK",
+      organizationEmail: `org@hngi7.com`,
+      secret: "shhhh!",
+      adminName: "ORG_MANAGER",
+      adminEmail: `org@comments.com`,
+      adminPassword: "thisisapassword",
     });
     await organization.save();
   });
@@ -24,16 +24,14 @@ describe("Delete /organizations/:organizationId", () => {
   });
 
   it("Deletes organization with provided ID", async () => {
-    let res = await request
-      .delete(`/v1/organization/${organization._id}`);
+    let res = await request.delete(`/v1/organization/${organization._id}`);
     expect(res.status).toEqual(200);
     expect(res.body.data.organizationId).toEqual(String(organization._id));
   });
 
   it("returns 404 for organization not found", async () => {
     let wrongId = mongoose.Types.ObjectId();
-    let res = await request
-      .delete(`/v1/organization/${wrongId}`);
+    let res = await request.delete(`/v1/organization/${wrongId}`);
     expect(res.status).toEqual(404);
     expect(res.body.status).toEqual("error");
   });

--- a/__test__/api/organizations/deleteSingleOrganization.js
+++ b/__test__/api/organizations/deleteSingleOrganization.js
@@ -1,0 +1,40 @@
+const app = require("../../../server");
+const supertest = require("supertest");
+const mongoose = require("mongoose");
+const OrganizationModel = require("../../../models/organizations");
+const request = supertest(app);
+
+describe("Delete /organizations/:organizationId", () => {
+  let organization;
+  beforeEach(async () => {
+    organization = new OrganizationModel({
+        organizationName: 'HNG SDK',
+        organizationEmail: `org@hngi7.com`,
+        secret: 'shhhh!',
+        adminName: 'ORG_MANAGER',
+        adminEmail: `org@comments.com`,
+        adminPassword: 'thisisapassword',
+    });
+    await organization.save();
+  });
+
+  afterEach(async () => {
+    await OrganizationModel.findByIdAndDelete(organization._id);
+    organization = null;
+  });
+
+  it("Deletes organization with provided ID", async () => {
+    let res = await request
+      .delete(`/v1/organization/${organization._id}`);
+    expect(res.status).toEqual(200);
+    expect(res.body.data.organizationId).toEqual(String(organization._id));
+  });
+
+  it("returns 404 for organization not found", async () => {
+    let wrongId = mongoose.Types.ObjectId();
+    let res = await request
+      .delete(`/v1/organization/${wrongId}`);
+    expect(res.status).toEqual(404);
+    expect(res.body.status).toEqual("error");
+  });
+});

--- a/__test__/api/pagination.test.js
+++ b/__test__/api/pagination.test.js
@@ -1,17 +1,17 @@
-const CommentModel = require('../../models/comments');
-const ReplyModel = require('../../models/replies');
-const replyHandler = require('../../utils/replyHandler');
-const app = require('../../server');
-const request = require('supertest');
+const CommentModel = require("../../models/comments");
+const ReplyModel = require("../../models/replies");
+const replyHandler = require("../../utils/replyHandler");
+const app = require("../../server");
+const request = require("supertest");
 
-describe('GET /comments', () => {
-  let comment, savedReply,reply;
+describe("GET /comments", () => {
+  let comment, savedReply, reply;
   beforeEach(async () => {
     // Mock a comment document
     const mockedCommentDoc = new CommentModel({
-      content: 'A comment from user 1',
-      ownerId: 'user1@email.com',
-      origin: '123123',
+      content: "A comment from user 1",
+      ownerId: "user1@email.com",
+      origin: "123123",
       refId: 2,
       applicationId: global.application._id,
     });
@@ -21,8 +21,8 @@ describe('GET /comments', () => {
 
     // Mock a reply document.
     const mockedReply1Doc = new ReplyModel({
-      content: 'A reply from user 2',
-      ownerId: 'user2@email.com',
+      content: "A reply from user 2",
+      ownerId: "user2@email.com",
       commentId: comment.id,
     });
 
@@ -50,23 +50,23 @@ describe('GET /comments', () => {
     reply = null;
   });
 
-  test('Should return error on limit exceeded on GET /comments', async () => {
+  test("Should return error on limit exceeded on GET /comments", async () => {
     const res = await request(app)
-      .get('/v1/comments')
+      .get("/v1/comments")
       .query({ limit: 60 })
-      .set('Authorization', `Bearer ${global.appToken}`);
+      .set("Authorization", `Bearer ${global.appToken}`);
     expect(res.status).toBe(422);
-    expect(res.body.status).toEqual('error');
+    expect(res.body.status).toEqual("error");
     expect(res.body.data).toEqual([]);
   });
 
-  test('Should return error on limit exceeded on GET ../replies', async () => {
+  test("Should return error on limit exceeded on GET ../replies", async () => {
     const res = await request(app)
       .get(`/v1/comments/${comment.commentId}/replies`)
       .query({ limit: 60 })
-      .set('Authorization', `Bearer ${global.appToken}`);
+      .set("Authorization", `Bearer ${global.appToken}`);
     expect(res.status).toBe(422);
-    expect(res.body.status).toEqual('error');
+    expect(res.body.status).toEqual("error");
     expect(res.body.data).toEqual([]);
   });
 });

--- a/__test__/api/pagination.test.js
+++ b/__test__/api/pagination.test.js
@@ -1,0 +1,72 @@
+const CommentModel = require('../../models/comments');
+const ReplyModel = require('../../models/replies');
+const replyHandler = require('../../utils/replyHandler');
+const app = require('../../server');
+const request = require('supertest');
+
+describe('GET /comments', () => {
+  let comment, savedReply,reply;
+  beforeEach(async () => {
+    // Mock a comment document
+    const mockedCommentDoc = new CommentModel({
+      content: 'A comment from user 1',
+      ownerId: 'user1@email.com',
+      origin: '123123',
+      refId: 2,
+      applicationId: global.application._id,
+    });
+
+    // Save mocked comment document to the database and cache.
+    comment = await mockedCommentDoc.save();
+
+    // Mock a reply document.
+    const mockedReply1Doc = new ReplyModel({
+      content: 'A reply from user 2',
+      ownerId: 'user2@email.com',
+      commentId: comment.id,
+    });
+
+    // Save mocked replies document to the database.
+    savedReply = await mockedReply1Doc.save();
+
+    // Add replies to the mocked comment.
+    await CommentModel.findByIdAndUpdate(comment.id, {
+      $push: {
+        replies: { $each: [savedReply.replyId] },
+      },
+    });
+
+    // Cache response objects
+    reply = replyHandler(savedReply);
+  });
+
+  afterEach(async () => {
+    // Delete mocks from the database.
+    await CommentModel.findByIdAndDelete(comment.id);
+    await ReplyModel.findByIdAndDelete(reply.replyId);
+
+    // Delete cache.
+    comment = null;
+    reply = null;
+  });
+
+  test('Should return error on limit exceeded on GET /comments', async () => {
+    const res = await request(app)
+      .get('/v1/comments')
+      .query({ limit: 60 })
+      .set('Authorization', `Bearer ${global.appToken}`);
+    expect(res.status).toBe(422);
+    expect(res.body.status).toEqual('error');
+    expect(res.body.data).toEqual([]);
+  });
+
+  test('Should return error on limit exceeded on GET ../replies', async () => {
+    const res = await request(app)
+      .get(`/v1/comments/${comment.commentId}/replies`)
+      .query({ limit: 60 })
+      .set('Authorization', `Bearer ${global.appToken}`);
+    expect(res.status).toBe(422);
+    expect(res.body.status).toEqual('error');
+    expect(res.body.data).toEqual([]);
+  });
+});

--- a/__test__/api/replies/getAllReplies.test.js
+++ b/__test__/api/replies/getAllReplies.test.js
@@ -1,37 +1,37 @@
-const app = require("../../../server");
-const ReplyModel = require("../../../models/replies");
-const CommentModel = require("../../../models/comments");
-const replyHandler = require("../../../utils/replyHandler");
+const app = require('../../../server');
+const ReplyModel = require('../../../models/replies');
+const CommentModel = require('../../../models/comments');
+const replyHandler = require('../../../utils/replyHandler');
 // const mongoose = require("mongoose");
-const supertest = require("supertest");
+const supertest = require('supertest');
 const request = supertest(app);
 
 // Cached comment and reply
 let comment;
 let reply1, reply2;
 
-describe("GET /comments/:commentId/replies", () => {
+describe('GET /comments/:commentId/replies', () => {
   beforeEach(async () => {
     // Mock a comment document.
     const mockedCommentDoc = new CommentModel({
-      content: "A comment from user 1",
-      ownerId: "user1@email.com",
-      origin: "123123",
+      content: 'A comment from user 1',
+      ownerId: 'user1@email.com',
+      origin: '123123',
       refId: 2,
       applicationId: global.application._id,
     });
 
     // Mock a reply document.
     const mockedReply1Doc = new ReplyModel({
-      content: "A reply from user 2",
-      ownerId: "user2@email.com",
+      content: 'A reply from user 2',
+      ownerId: 'user2@email.com',
       commentId: mockedCommentDoc.id,
     });
 
     // Mock a reply document.
     const mockedReply2Doc = new ReplyModel({
-      content: "A reply from user 3",
-      ownerId: "user3@email.com",
+      content: 'A reply from user 3',
+      ownerId: 'user3@email.com',
       commentId: mockedCommentDoc.id,
       flags: [mockedCommentDoc.ownerId],
     });
@@ -67,104 +67,176 @@ describe("GET /comments/:commentId/replies", () => {
     reply2 = null;
   });
 
-  it("Should get all replies of a comment", () => {
+  it('Should get all replies of a comment', () => {
     const url = `/v1/comments/${comment.id}/replies`;
     const bearerToken = `bearer ${global.appToken}`;
 
     const getAllRepliesRequest = request
       .get(url)
-      .set("Authorization", bearerToken);
+      .set('Authorization', bearerToken);
 
     const expectedValue = [reply1, reply2];
 
     return getAllRepliesRequest.then((res) => {
       expect(res.status).toEqual(200);
-      expect(res.body.status).toEqual("success");
-      expect(res.body.data).toEqual(expectedValue);
+      expect(res.body.status).toEqual('success');
+      expect(res.body.data.records).toEqual(expectedValue);
     });
   });
 
-  it("Should get all replies, with a certain ownerId, of a comment", () => {
+  it('Should get all replies, with a certain ownerId, of a comment', () => {
     const url = `/v1/comments/${comment.id}/replies`;
     const bearerToken = `bearer ${global.appToken}`;
 
     const getAllRepliesRequest = request
       .get(url)
       .query({ ownerId: reply1.ownerId })
-      .set("Authorization", bearerToken);
+      .set('Authorization', bearerToken);
 
     const expectedValue = [reply1];
 
     return getAllRepliesRequest.then((res) => {
       expect(res.status).toEqual(200);
-      expect(res.body.status).toEqual("success");
-      expect(res.body.data).toEqual(expectedValue);
+      expect(res.body.status).toEqual('success');
+      expect(res.body.data.records).toEqual(expectedValue);
     });
   });
 
-  it("Should get all flagged replies of a comment", () => {
+  it('Should get all flagged replies of a comment', () => {
     const url = `/v1/comments/${comment.id}/replies`;
     const bearerToken = `bearer ${global.appToken}`;
 
     const getAllRepliesRequest = request
       .get(url)
       .query({ isFlagged: true })
-      .set("Authorization", bearerToken);
+      .set('Authorization', bearerToken);
 
     const expectedValue = [reply2];
 
     return getAllRepliesRequest.then((res) => {
-      // console.log(res.body.data);
+      // console.log(res.body.data.records);
       expect(res.status).toEqual(200);
-      expect(res.body.status).toEqual("success");
-      expect(res.body.data).toEqual(expectedValue);
+      expect(res.body.status).toEqual('success');
+      expect(res.body.data.records).toEqual(expectedValue);
     });
   });
 
-  it("Should get all unflagged replies of a comment", () => {
+  it('Should get all unflagged replies of a comment', () => {
     const url = `/v1/comments/${comment.id}/replies`;
     const bearerToken = `bearer ${global.appToken}`;
 
     const getAllRepliesRequest = request
       .get(url)
       .query({ isFlagged: false })
-      .set("Authorization", bearerToken);
+      .set('Authorization', bearerToken);
 
     const expectedValue = [reply1];
 
     return getAllRepliesRequest.then((res) => {
       expect(res.status).toEqual(200);
-      expect(res.body.status).toEqual("success");
-      expect(res.body.data).toEqual(expectedValue);
+      expect(res.body.status).toEqual('success');
+      expect(res.body.data.records).toEqual(expectedValue);
     });
   });
 
-  it("Should return a 401 error when authorization token is unauthorized", () => {
+  it('Should get all replies with set limit', () => {
+    const url = `/v1/comments/${comment.id}/replies`;
+    const bearerToken = `bearer ${global.appToken}`;
+
+    const getAllRepliesRequest = request
+      .get(url)
+      .query({ limit: 1 })
+      .set('Authorization', bearerToken);
+
+    const expectedValue = [reply1];
+
+    return getAllRepliesRequest.then((res) => {
+      expect(res.status).toEqual(200);
+      expect(res.body.status).toEqual('success');
+      expect(res.body.data.records).toEqual(expectedValue);
+    });
+  });
+
+  it('Should get all replies with set page', () => {
+    const url = `/v1/comments/${comment.id}/replies`;
+    const bearerToken = `bearer ${global.appToken}`;
+
+    const getAllRepliesRequest = request
+      .get(url)
+      .query({ page: 1 })
+      .set('Authorization', bearerToken);
+
+    const expectedValue = [reply1,reply2];
+
+    return getAllRepliesRequest.then((res) => {
+      expect(res.status).toEqual(200);
+      expect(res.body.status).toEqual('success');
+      expect(res.body.data.records).toEqual(expectedValue);
+    });
+  });
+
+  it('Should get all replies with set sort type', () => {
+    const url = `/v1/comments/${comment.id}/replies`;
+    const bearerToken = `bearer ${global.appToken}`;
+
+    const getAllRepliesRequest = request
+      .get(url)
+      .query({ sort: 'asc' })
+      .set('Authorization', bearerToken);
+
+    const expectedValue = [reply1, reply2];
+
+    return getAllRepliesRequest.then((res) => {
+      expect(res.status).toEqual(200);
+      expect(res.body.status).toEqual('success');
+      expect(res.body.data.records).toEqual(expectedValue);
+    });
+  });
+
+  it('Should get all replies with all pagination params set', () => {
+    const url = `/v1/comments/${comment.id}/replies`;
+    const bearerToken = `bearer ${global.appToken}`;
+
+    const getAllRepliesRequest = request
+      .get(url)
+      .query({ limit: 1, page: 1, sort: 'asc' })
+      .set('Authorization', bearerToken);
+
+    const expectedValue = [reply1];
+
+    return getAllRepliesRequest.then((res) => {
+      expect(res.status).toEqual(200);
+      expect(res.body.status).toEqual('success');
+      expect(res.body.data.records).toEqual(expectedValue);
+    });
+  });
+
+  it('Should return a 401 error when authorization token is unauthorized', () => {
     const url = `/v1/comments/${comment.id}/replies`;
     const bearerToken = `bearer `;
 
     const getAllRepliesRequest = request
       .get(url)
-      .set("Authorization", bearerToken);
+      .set('Authorization', bearerToken);
 
     return getAllRepliesRequest.then((res) => {
       expect(res.status).toEqual(401);
-      expect(res.body.status).toEqual("error");
+      expect(res.body.status).toEqual('error');
       expect(res.body.data).toEqual([]);
     });
   });
 
-  it("Should return a 404 error when commentId is not an existing ID", () => {
+  it('Should return a 404 error when commentId is not an existing ID', () => {
     const url = `/v1/comments/5eff06f9fa2a9a0017469f54/replies`;
     const bearerToken = `bearer ${global.appToken}`;
 
     const getAllRepliesRequest = request
       .get(url)
-      .set("Authorization", bearerToken);
+      .set('Authorization', bearerToken);
 
     return getAllRepliesRequest.then((res) => {
       expect(res.status).toEqual(404);
-      expect(res.body.status).toEqual("error");
+      expect(res.body.status).toEqual('error');
       expect(res.body.data).toEqual([]);
     });
   });

--- a/__test__/api/replies/getAllReplies.test.js
+++ b/__test__/api/replies/getAllReplies.test.js
@@ -1,37 +1,37 @@
-const app = require('../../../server');
-const ReplyModel = require('../../../models/replies');
-const CommentModel = require('../../../models/comments');
-const replyHandler = require('../../../utils/replyHandler');
+const app = require("../../../server");
+const ReplyModel = require("../../../models/replies");
+const CommentModel = require("../../../models/comments");
+const replyHandler = require("../../../utils/replyHandler");
 // const mongoose = require("mongoose");
-const supertest = require('supertest');
+const supertest = require("supertest");
 const request = supertest(app);
 
 // Cached comment and reply
 let comment;
 let reply1, reply2;
 
-describe('GET /comments/:commentId/replies', () => {
+describe("GET /comments/:commentId/replies", () => {
   beforeEach(async () => {
     // Mock a comment document.
     const mockedCommentDoc = new CommentModel({
-      content: 'A comment from user 1',
-      ownerId: 'user1@email.com',
-      origin: '123123',
+      content: "A comment from user 1",
+      ownerId: "user1@email.com",
+      origin: "123123",
       refId: 2,
       applicationId: global.application._id,
     });
 
     // Mock a reply document.
     const mockedReply1Doc = new ReplyModel({
-      content: 'A reply from user 2',
-      ownerId: 'user2@email.com',
+      content: "A reply from user 2",
+      ownerId: "user2@email.com",
       commentId: mockedCommentDoc.id,
     });
 
     // Mock a reply document.
     const mockedReply2Doc = new ReplyModel({
-      content: 'A reply from user 3',
-      ownerId: 'user3@email.com',
+      content: "A reply from user 3",
+      ownerId: "user3@email.com",
       commentId: mockedCommentDoc.id,
       flags: [mockedCommentDoc.ownerId],
     });
@@ -67,176 +67,176 @@ describe('GET /comments/:commentId/replies', () => {
     reply2 = null;
   });
 
-  it('Should get all replies of a comment', () => {
+  it("Should get all replies of a comment", () => {
     const url = `/v1/comments/${comment.id}/replies`;
     const bearerToken = `bearer ${global.appToken}`;
 
     const getAllRepliesRequest = request
       .get(url)
-      .set('Authorization', bearerToken);
+      .set("Authorization", bearerToken);
 
     const expectedValue = [reply1, reply2];
 
     return getAllRepliesRequest.then((res) => {
       expect(res.status).toEqual(200);
-      expect(res.body.status).toEqual('success');
+      expect(res.body.status).toEqual("success");
       expect(res.body.data.records).toEqual(expectedValue);
     });
   });
 
-  it('Should get all replies, with a certain ownerId, of a comment', () => {
+  it("Should get all replies, with a certain ownerId, of a comment", () => {
     const url = `/v1/comments/${comment.id}/replies`;
     const bearerToken = `bearer ${global.appToken}`;
 
     const getAllRepliesRequest = request
       .get(url)
       .query({ ownerId: reply1.ownerId })
-      .set('Authorization', bearerToken);
+      .set("Authorization", bearerToken);
 
     const expectedValue = [reply1];
 
     return getAllRepliesRequest.then((res) => {
       expect(res.status).toEqual(200);
-      expect(res.body.status).toEqual('success');
+      expect(res.body.status).toEqual("success");
       expect(res.body.data.records).toEqual(expectedValue);
     });
   });
 
-  it('Should get all flagged replies of a comment', () => {
+  it("Should get all flagged replies of a comment", () => {
     const url = `/v1/comments/${comment.id}/replies`;
     const bearerToken = `bearer ${global.appToken}`;
 
     const getAllRepliesRequest = request
       .get(url)
       .query({ isFlagged: true })
-      .set('Authorization', bearerToken);
+      .set("Authorization", bearerToken);
 
     const expectedValue = [reply2];
 
     return getAllRepliesRequest.then((res) => {
       // console.log(res.body.data.records);
       expect(res.status).toEqual(200);
-      expect(res.body.status).toEqual('success');
+      expect(res.body.status).toEqual("success");
       expect(res.body.data.records).toEqual(expectedValue);
     });
   });
 
-  it('Should get all unflagged replies of a comment', () => {
+  it("Should get all unflagged replies of a comment", () => {
     const url = `/v1/comments/${comment.id}/replies`;
     const bearerToken = `bearer ${global.appToken}`;
 
     const getAllRepliesRequest = request
       .get(url)
       .query({ isFlagged: false })
-      .set('Authorization', bearerToken);
+      .set("Authorization", bearerToken);
 
     const expectedValue = [reply1];
 
     return getAllRepliesRequest.then((res) => {
       expect(res.status).toEqual(200);
-      expect(res.body.status).toEqual('success');
+      expect(res.body.status).toEqual("success");
       expect(res.body.data.records).toEqual(expectedValue);
     });
   });
 
-  it('Should get all replies with set limit', () => {
+  it("Should get all replies with set limit", () => {
     const url = `/v1/comments/${comment.id}/replies`;
     const bearerToken = `bearer ${global.appToken}`;
 
     const getAllRepliesRequest = request
       .get(url)
       .query({ limit: 1 })
-      .set('Authorization', bearerToken);
+      .set("Authorization", bearerToken);
 
     const expectedValue = [reply1];
 
     return getAllRepliesRequest.then((res) => {
       expect(res.status).toEqual(200);
-      expect(res.body.status).toEqual('success');
+      expect(res.body.status).toEqual("success");
       expect(res.body.data.records).toEqual(expectedValue);
     });
   });
 
-  it('Should get all replies with set page', () => {
+  it("Should get all replies with set page", () => {
     const url = `/v1/comments/${comment.id}/replies`;
     const bearerToken = `bearer ${global.appToken}`;
 
     const getAllRepliesRequest = request
       .get(url)
       .query({ page: 1 })
-      .set('Authorization', bearerToken);
-
-    const expectedValue = [reply1,reply2];
-
-    return getAllRepliesRequest.then((res) => {
-      expect(res.status).toEqual(200);
-      expect(res.body.status).toEqual('success');
-      expect(res.body.data.records).toEqual(expectedValue);
-    });
-  });
-
-  it('Should get all replies with set sort type', () => {
-    const url = `/v1/comments/${comment.id}/replies`;
-    const bearerToken = `bearer ${global.appToken}`;
-
-    const getAllRepliesRequest = request
-      .get(url)
-      .query({ sort: 'asc' })
-      .set('Authorization', bearerToken);
+      .set("Authorization", bearerToken);
 
     const expectedValue = [reply1, reply2];
 
     return getAllRepliesRequest.then((res) => {
       expect(res.status).toEqual(200);
-      expect(res.body.status).toEqual('success');
+      expect(res.body.status).toEqual("success");
       expect(res.body.data.records).toEqual(expectedValue);
     });
   });
 
-  it('Should get all replies with all pagination params set', () => {
+  it("Should get all replies with set sort type", () => {
     const url = `/v1/comments/${comment.id}/replies`;
     const bearerToken = `bearer ${global.appToken}`;
 
     const getAllRepliesRequest = request
       .get(url)
-      .query({ limit: 1, page: 1, sort: 'asc' })
-      .set('Authorization', bearerToken);
+      .query({ sort: "asc" })
+      .set("Authorization", bearerToken);
+
+    const expectedValue = [reply1, reply2];
+
+    return getAllRepliesRequest.then((res) => {
+      expect(res.status).toEqual(200);
+      expect(res.body.status).toEqual("success");
+      expect(res.body.data.records).toEqual(expectedValue);
+    });
+  });
+
+  it("Should get all replies with all pagination params set", () => {
+    const url = `/v1/comments/${comment.id}/replies`;
+    const bearerToken = `bearer ${global.appToken}`;
+
+    const getAllRepliesRequest = request
+      .get(url)
+      .query({ limit: 1, page: 1, sort: "asc" })
+      .set("Authorization", bearerToken);
 
     const expectedValue = [reply1];
 
     return getAllRepliesRequest.then((res) => {
       expect(res.status).toEqual(200);
-      expect(res.body.status).toEqual('success');
+      expect(res.body.status).toEqual("success");
       expect(res.body.data.records).toEqual(expectedValue);
     });
   });
 
-  it('Should return a 401 error when authorization token is unauthorized', () => {
+  it("Should return a 401 error when authorization token is unauthorized", () => {
     const url = `/v1/comments/${comment.id}/replies`;
     const bearerToken = `bearer `;
 
     const getAllRepliesRequest = request
       .get(url)
-      .set('Authorization', bearerToken);
+      .set("Authorization", bearerToken);
 
     return getAllRepliesRequest.then((res) => {
       expect(res.status).toEqual(401);
-      expect(res.body.status).toEqual('error');
+      expect(res.body.status).toEqual("error");
       expect(res.body.data).toEqual([]);
     });
   });
 
-  it('Should return a 404 error when commentId is not an existing ID', () => {
+  it("Should return a 404 error when commentId is not an existing ID", () => {
     const url = `/v1/comments/5eff06f9fa2a9a0017469f54/replies`;
     const bearerToken = `bearer ${global.appToken}`;
 
     const getAllRepliesRequest = request
       .get(url)
-      .set('Authorization', bearerToken);
+      .set("Authorization", bearerToken);
 
     return getAllRepliesRequest.then((res) => {
       expect(res.status).toEqual(404);
-      expect(res.body.status).toEqual('error');
+      expect(res.body.status).toEqual("error");
       expect(res.body.data).toEqual([]);
     });
   });

--- a/controllers/commentsController/getAllComments.js
+++ b/controllers/commentsController/getAllComments.js
@@ -1,9 +1,9 @@
 // Models
-const Comments = require('../../models/comments');
+const Comments = require("../../models/comments");
 
 // Utilities
-const CustomError = require('../../utils/customError');
-const responseHandler = require('../../utils/responseHandler');
+const CustomError = require("../../utils/customError");
+const responseHandler = require("../../utils/responseHandler");
 
 /**
  * @author Airon <airondev@gmail.com>
@@ -48,13 +48,13 @@ const getAllComments = async (req, res, next) => {
   //set sort if available
   sort
     ? (paginateOptions.sort = { createdAt: sort })
-    : (paginateOptions.sort = { createdAt: 'asc' });
+    : (paginateOptions.sort = { createdAt: "asc" });
 
-  if (typeof isFlagged === 'string') {
-    if (isFlagged === 'true') {
-      query['flags.0'] = { $exists: true };
-    } else if (isFlagged === 'false') {
-      query['flags.0'] = { $exists: false };
+  if (typeof isFlagged === "string") {
+    if (isFlagged === "true") {
+      query["flags.0"] = { $exists: true };
+    } else if (isFlagged === "false") {
+      query["flags.0"] = { $exists: false };
     }
   }
 
@@ -99,8 +99,8 @@ const getAllComments = async (req, res, next) => {
         if (data.pageInfo.currentPage > data.pageInfo.totalPages) {
           return next(
             new CustomError(
-              '404',
-              'Page limit exceeded, No records found!',
+              "404",
+              "Page limit exceeded, No records found!",
               data.pageInfo
             )
           );

--- a/controllers/commentsController/getAllComments.js
+++ b/controllers/commentsController/getAllComments.js
@@ -36,7 +36,7 @@ const getAllComments = async (req, res, next) => {
 
   sort
     ? (paginateOption.sort = { createdAt: sort })
-    : (paginateOption.sort = { createdAt: "desc" });
+    : (paginateOption.sort = { createdAt: "asc" });
 
   if (typeof isFlagged === "string") {
     if (isFlagged === "true") {

--- a/controllers/organizationsController/deleteSingleOrganization.js
+++ b/controllers/organizationsController/deleteSingleOrganization.js
@@ -1,16 +1,16 @@
-const mongoose = require('mongoose');
-const CustomError = require('../../utils/customError');
-const responseHandler = require('../../utils/responseHandler');
-const Organizations = require('../../models/organizations');
-const Admins = require('../../models/admins');
+const mongoose = require("mongoose");
+const CustomError = require("../../utils/customError");
+const responseHandler = require("../../utils/responseHandler");
+const Organizations = require("../../models/organizations");
+const Admins = require("../../models/admins");
 
 const deleteSingleOrganization = async (req, res, next) => {
   const organizationId = req.params.organizationId;
   try {
-    const organization = await Organizations.findById(applicationId);
+    const organization = await Organizations.findById(organizationId);
     if (!organization) {
       return next(
-        new CustomError(404, 'Organization not found or have been removed')
+        new CustomError(404, "Organization not found or have been removed")
       );
     }
     if (
@@ -24,29 +24,31 @@ const deleteSingleOrganization = async (req, res, next) => {
     }
   } catch (err) {
     return next(
-      new CustomError(500, 'Something went wrong,please try again', err.message)
+      new CustomError(500, "Something went wrong,please try again", err.message)
     );
   }
   try {
     const admins = await Admins.find({ organizationId: organizationId });
     if (!admins) {
-      return next(new CustomError(404, 'Admin(s) not found'));
+      return next(new CustomError(404, "Admin(s) not found"));
     }
     await admins.remove();
-  } catch (error) {}
+  } catch (error) {
+    return next(new CustomError(400, "Delete not Successful"));
+  }
   Organizations.findByIdAndDelete(organizationId)
     .then((org) => {
       const data = {
         organizationId: org._id,
         name: org.name,
       };
-      responseHandler(res, 200, data, 'Organization deleted successfully');
+      responseHandler(res, 200, data, "Organization deleted successfully");
     })
     .catch((err) => {
       return next(
         new CustomError(
           500,
-          'Something went wrong, please try again',
+          "Something went wrong, please try again",
           err.message
         )
       );

--- a/controllers/organizationsController/deleteSingleOrganization.js
+++ b/controllers/organizationsController/deleteSingleOrganization.js
@@ -1,0 +1,55 @@
+const mongoose = require('mongoose');
+const CustomError = require('../../utils/customError');
+const responseHandler = require('../../utils/responseHandler');
+const Organizations = require('../../models/organizations');
+const Admins = require('../../models/admins');
+
+const deleteSingleOrganization = async (req, res, next) => {
+  const organizationId = req.params.organizationId;
+  try {
+    const organization = await Organizations.findById(applicationId);
+    if (!organization) {
+      return next(
+        new CustomError(404, 'Organization not found or have been removed')
+      );
+    }
+    if (
+      !mongoose.Types.ObjectId(organization.organizationId).equals(
+        mongoose.Types.ObjectId(organizationId)
+      )
+    ) {
+      return next(
+        new CustomError(401, "You're not allowed to access this resource")
+      );
+    }
+  } catch (err) {
+    return next(
+      new CustomError(500, 'Something went wrong,please try again', err.message)
+    );
+  }
+  try {
+    const admins = await Admins.find({ organizationId: organizationId });
+    if (!admins) {
+      return next(new CustomError(404, 'Admin(s) not found'));
+    }
+    await admins.remove();
+  } catch (error) {}
+  Organizations.findByIdAndDelete(organizationId)
+    .then((org) => {
+      const data = {
+        organizationId: org._id,
+        name: org.name,
+      };
+      responseHandler(res, 200, data, 'Organization deleted successfully');
+    })
+    .catch((err) => {
+      return next(
+        new CustomError(
+          500,
+          'Something went wrong, please try again',
+          err.message
+        )
+      );
+    });
+};
+module.exports = deleteSingleOrganization;

--- a/controllers/organizationsController/index.js
+++ b/controllers/organizationsController/index.js
@@ -2,7 +2,10 @@
 const createSingleOrganization = require("./createSingleOrganization");
 const getSingleOrganizationToken = require("./getSingleOrganizationToken");
 
+//DELETE
+const deleteSingleOrganization = require("./deleteSingleOrganization")
 module.exports = {
   createSingleOrganization,
   getSingleOrganizationToken,
+  deleteSingleOrganization,
 };

--- a/controllers/organizationsController/index.js
+++ b/controllers/organizationsController/index.js
@@ -3,7 +3,7 @@ const createSingleOrganization = require("./createSingleOrganization");
 const getSingleOrganizationToken = require("./getSingleOrganizationToken");
 
 //DELETE
-const deleteSingleOrganization = require("./deleteSingleOrganization")
+const deleteSingleOrganization = require("./deleteSingleOrganization");
 module.exports = {
   createSingleOrganization,
   getSingleOrganizationToken,

--- a/controllers/repliesController/getAllReplies.js
+++ b/controllers/repliesController/getAllReplies.js
@@ -1,12 +1,12 @@
-const { ObjectId } = require('mongoose').Types;
+const { ObjectId } = require("mongoose").Types;
 
 // Models
-const Comments = require('../../models/comments');
-const Replies = require('../../models/replies');
+const Comments = require("../../models/comments");
+const Replies = require("../../models/replies");
 
 // Utilities
-const CustomError = require('../../utils/customError');
-const responseHandler = require('../../utils/responseHandler');
+const CustomError = require("../../utils/customError");
+const responseHandler = require("../../utils/responseHandler");
 
 /**
  * @author
@@ -23,14 +23,14 @@ const getAllReplies = async (req, res, next) => {
   const { applicationId } = req.token;
 
   if (!ObjectId.isValid(commentId)) {
-    return next(new CustomError(400, 'Invalid comment Id '));
+    return next(new CustomError(400, "Invalid comment Id "));
   }
   try {
     //check if such comment exists
     const comment = await Comments.findOne({ _id: commentId, applicationId });
     // If the comment does not exist,send an error msg
     if (!comment) {
-      return next(new CustomError(404, ' Comment not found '));
+      return next(new CustomError(404, " Comment not found "));
     }
 
     // Create query for replies.
@@ -60,14 +60,14 @@ const getAllReplies = async (req, res, next) => {
     //set sort if available
     sort
       ? (paginateOptions.sort = { createdAt: sort })
-      : (paginateOptions.sort = { createdAt: 'asc' });
+      : (paginateOptions.sort = { createdAt: "asc" });
 
     //flag check
-    if (typeof isFlagged === 'string') {
-      if (isFlagged === 'true') {
-        query['flags.0'] = { $exists: true };
-      } else if (isFlagged === 'false') {
-        query['flags.0'] = { $exists: false };
+    if (typeof isFlagged === "string") {
+      if (isFlagged === "true") {
+        query["flags.0"] = { $exists: true };
+      } else if (isFlagged === "false") {
+        query["flags.0"] = { $exists: false };
       }
     }
 
@@ -101,9 +101,9 @@ const getAllReplies = async (req, res, next) => {
     };
 
     //set response message
-    let message = ' Replies found. ';
+    let message = " Replies found. ";
     if (!allReplies.length) {
-      message = ' No replies found. ';
+      message = " No replies found. ";
     }
     //set data properties
     let data = {
@@ -113,8 +113,8 @@ const getAllReplies = async (req, res, next) => {
     if (data.pageInfo.currentPage > data.pageInfo.totalPages) {
       return next(
         new CustomError(
-          '404',
-          'Page limit exceeded, No records found!',
+          "404",
+          "Page limit exceeded, No records found!",
           data.pageInfo
         )
       );

--- a/controllers/repliesController/getAllReplies.js
+++ b/controllers/repliesController/getAllReplies.js
@@ -1,12 +1,12 @@
-const { ObjectId } = require("mongoose").Types;
+const { ObjectId } = require('mongoose').Types;
 
 // Models
-const Comments = require("../../models/comments");
-const Replies = require("../../models/replies");
+const Comments = require('../../models/comments');
+const Replies = require('../../models/replies');
 
 // Utilities
-const CustomError = require("../../utils/customError");
-const responseHandler = require("../../utils/responseHandler");
+const CustomError = require('../../utils/customError');
+const responseHandler = require('../../utils/responseHandler');
 
 /**
  * @author
@@ -19,57 +19,61 @@ const responseHandler = require("../../utils/responseHandler");
  */
 const getAllReplies = async (req, res, next) => {
   const { commentId } = req.params;
-  const { isFlagged, ownerId, limit, offset, sort } = req.query;
+  const { isFlagged, ownerId, limit, page, sort } = req.query;
   const { applicationId } = req.token;
 
   if (!ObjectId.isValid(commentId)) {
-    return next(new CustomError(400, "Invalid comment Id "));
+    return next(new CustomError(400, 'Invalid comment Id '));
   }
   try {
     //check if such comment exists
     const comment = await Comments.findOne({ _id: commentId, applicationId });
     // If the comment does not exist,send an error msg
     if (!comment) {
-      return next(new CustomError(404, " Comment not found "));
+      return next(new CustomError(404, ' Comment not found '));
     }
 
     // Create query for replies.
     let query = {};
     // Create paginiation options
-    let paginateOption = {};
+    let paginateOptions = {};
 
     query.commentId = commentId;
     if (ownerId) query.ownerId = ownerId;
+    /**
+     * Pagingation starts here
+     */
 
-    //set limit query
-    if (limit) {
-      paginateOption.limit = parseInt(limit, 10);
-    }
-    //set offset query
-    offset
-      ? (paginateOption.offset = parseInt(offset, 10))
-      : (paginateOption.offset = 0);
+    //set record limit if available
+    limit
+      ? (paginateOptions.limit = parseInt(limit, 10))
+      : (paginateOptions.limit = 20);
 
-    //set sort query
+    //set skip to next page if available
+    paginateOptions.skip = (page - 1) * limit;
+
+    //set page option if available
+    page
+      ? (paginateOptions.page = parseInt(page, 10))
+      : (paginateOptions.page = 1);
+
+    //set sort if available
     sort
-      ? (paginateOption.sort = { createdAt: sort })
-      : (paginateOption.sort = { createdAt: "asc" });
+      ? (paginateOptions.sort = { createdAt: sort })
+      : (paginateOptions.sort = { createdAt: 'asc' });
 
-    if (typeof isFlagged === "string") {
-      if (isFlagged === "true") {
-        query["flags.0"] = { $exists: true };
-      } else if (isFlagged === "false") {
-        query["flags.0"] = { $exists: false };
+    //flag check
+    if (typeof isFlagged === 'string') {
+      if (isFlagged === 'true') {
+        query['flags.0'] = { $exists: true };
+      } else if (isFlagged === 'false') {
+        query['flags.0'] = { $exists: false };
       }
     }
 
-    const replies = await Replies.paginate(query, paginateOption);
-    let message = " Replies found. ";
-    if (!replies.length) {
-      message = " No replies found. ";
-    }
+    const replies = await Replies.paginate(query, paginateOptions);
 
-    const data = replies.docs.map((reply) => {
+    const allReplies = replies.docs.map((reply) => {
       return {
         replyId: reply._id,
         commentId: reply.commentId,
@@ -84,7 +88,39 @@ const getAllReplies = async (req, res, next) => {
       };
     });
 
-    return responseHandler(res, 200, data, message);
+    //set page info
+    let pageInfo = {
+      currentPage: replies.page,
+      totalPages: replies.totalPages,
+      hasNext: replies.hasNextPage,
+      hasPrev: replies.hasPrevPage,
+      nextPage: replies.nextPage,
+      prevPage: replies.prevPage,
+      pageRecordCount: replies.docs.length,
+      totalRecord: replies.totalDocs,
+    };
+
+    //set response message
+    let message = ' Replies found. ';
+    if (!allReplies.length) {
+      message = ' No replies found. ';
+    }
+    //set data properties
+    let data = {
+      records: allReplies,
+      pageInfo: pageInfo,
+    };
+    if (data.pageInfo.currentPage > data.pageInfo.totalPages) {
+      return next(
+        new CustomError(
+          '404',
+          'Page limit exceeded, No records found!',
+          data.pageInfo
+        )
+      );
+    } else {
+      responseHandler(res, 200, data, message);
+    }
   } catch (err) {
     next(err);
   }

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -882,6 +882,15 @@ paths:
 
         - in: query
           $ref: "#/components/parameters/originParam"
+        
+        - in: query
+          $ref: "#/components/parameters/limitParam"
+
+        - in: query
+          $ref: "#/components/parameters/sortParam"
+        
+        - in: query
+          $ref: "#/components/parameters/pageParam"
 
       responses:
         "200":
@@ -900,9 +909,14 @@ paths:
                   status:
                     type: string
                   data:
-                    type: array
-                    items:
-                      $ref: "#/components/schemas/Comment"
+                    type: object
+                    properties:
+                      records:
+                        type: array
+                        items:
+                          $ref: "#/components/schemas/Comment"
+                      pageInfo:
+                          $ref: "#/components/schemas/pageInfo"
 
         "401":
           description: Authentication error
@@ -1464,6 +1478,15 @@ paths:
         - in: query
           $ref: "#/components/parameters/ownerIdParam"
 
+        - in: query
+          $ref: "#/components/parameters/limitParam"
+
+        - in: query
+          $ref: "#/components/parameters/sortParam"
+        
+        - in: query
+          $ref: "#/components/parameters/pageParam"
+
       responses:
         "200":
           description: Successful operation
@@ -1481,9 +1504,14 @@ paths:
                   status:
                     type: string
                   data:
-                    type: array
-                    items:
-                      $ref: "#/components/schemas/Reply"
+                    type: object
+                    properties:
+                      records:
+                        type: array
+                        items:
+                          $ref: "#/components/schemas/Reply"
+                      pageInfo:
+                        $ref: "#/components/schemas/pageInfo"
 
         "401":
           description: Authentication error
@@ -2151,7 +2179,7 @@ components:
           type: string
         organizationToken:
           type: string
-
+ 
     Admin: # Can be referenced as '#/components/schemas/Admin'
       type: object
       required:
@@ -2261,6 +2289,35 @@ components:
         updatedAt:
           type: string
 
+    pageInfo: # Can be referenced as '#/components/schemas/pageInfo'  
+      type: object
+      required:
+        - currentPage
+        - totalPages
+        - hasNext
+        - hasPrev
+        - nextPage
+        - prevPage
+        - pageRecordCount
+        - totalRecord
+      properties:        
+        currentPage:
+          type: number
+        totalPages:
+          type: number
+        hasNext:
+          type: boolean
+        hasPrev:
+          type: boolean
+        nextPage:
+          type: number
+        prevPage:
+          type: number
+        pageRecordCount:
+          type: number
+        totalRecord:
+          type: number
+    
     CreateComment: # Can be referenced as '#/components/schemas/CreateComment'
       type: object
       required:
@@ -2506,5 +2563,26 @@ components:
       in: query
       name: origin
       description: Filters comments, or replies, by origin. If omitted, the response includes all comments, or replies, regardless of its origin.
+      schema:
+        type: string
+
+    limitParam: # Can be referenced via '#/components/parameters/limitParam'
+      in: query
+      name: limit
+      description: Returns set number of comments, or replies perPage. If omitted, the response includes all comments, or replies, regardless of its limits.
+      schema:
+        type: string
+
+    sortParam: # Can be referenced via '#/components/parameters/limitParam'
+      in: query
+      name: sort
+      description: Sorts comments, or replies and returns in ascending or descending order. If omitted, the response includes all comments, or replies in ascending order.
+      schema:
+        type: string
+
+    pageParam: # Can be referenced via '#/components/parameters/limitParam'
+      in: query
+      name: page
+      description: Paginates comments, or replies. If omitted, the response includes all comments, or replies in one page.
       schema:
         type: string

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -128,6 +128,57 @@ paths:
               schema:
                 $ref: "#/components/schemas/ErrorResponse"
 
+  # Endpoint to delete an organization
+  /organizations/{organizationId}:
+    # DELETE operation
+    delete:
+      tags:
+        - Organizations
+
+      summary: Delete an Organization
+
+      parameters:
+        - in: path
+          $ref: "#/components/parameters/organizationIdParam"
+
+      responses:
+        "200":
+          description: Successful operation
+          content:
+            application/json:
+              schema:
+                type: object
+                required:
+                  - message
+                  - status
+                  - data
+                properties:
+                  message:
+                    type: string
+                  status:
+                    type: string
+                  data:
+                    $ref: "#/components/schemas/DeleteOrganization"
+        "401":
+          description: Authentication error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+
+        "404":
+          description: Invalid ID error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+
+        "422":
+          description: Validation error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
   # Endpoint to create an organization's admin
   /admins:
     # GET operation
@@ -2064,6 +2115,14 @@ components:
           type: string
           format: email
         secret:
+          type: string
+
+    DeleteOrganization: # Can be referenced as '#/components/schemas/DeleteOrganization'
+      type: object
+      properties:
+        organizationId:
+          type: string
+        organizationName:
           type: string
 
     LoginOrganization: # Can be referenced as '#/components/schemas/LoginOrganization'

--- a/middleware/pagination.js
+++ b/middleware/pagination.js
@@ -1,21 +1,20 @@
-const CustomError = require("../utils/customError");
+const CustomError = require('../utils/customError');
 
 exports.queryLimitMW = (req, res, next) => {
   //get limit peck config
   const limitPeck = 50;
   //check if GET request
-  if (req.method === "GET") {
+  if (req.method === 'GET') {
     //check if req.limit is set
-    if (req.params.limit) {
-      try {
-        if (parseInt(req.params.limit, 10) > limitPeck) {
-          req.params.limit = limitPeck.toString();
-          res.json({
-            message: `Limit Pecked at ${limitPeck}`,
-          });
-        }
-      } catch (error) {
-        next(CustomError(422, "Invalid limit specified"));
+    if (req.query.limit) {
+      if (parseInt(req.query.limit, 10) > limitPeck) {
+        req.query.limit = limitPeck.toString();
+        return next(
+          new CustomError(
+            422,
+            `Invalid limit specified. Query Limit Pecked at ${limitPeck}`
+          )
+        );
       }
     }
   }

--- a/middleware/pagination.js
+++ b/middleware/pagination.js
@@ -1,6 +1,6 @@
 const CustomError = require("../utils/customError");
 
-const queryLimitMW = (req, res, next) => {
+exports.queryLimitMW = (req, res, next) => {
   //get limit peck config
   const limitPeck = 50;
   //check if GET request
@@ -21,5 +21,3 @@ const queryLimitMW = (req, res, next) => {
   }
   next();
 };
-
-module.exports = queryLimitMW;

--- a/middleware/pagination.js
+++ b/middleware/pagination.js
@@ -1,0 +1,25 @@
+const CustomError = require("../utils/customError");
+
+const queryLimitMW = (req, res, next) => {
+  //get limit peck config
+  const limitPeck = 50;
+  //check if GET request
+  if (req.method === "GET") {
+    //check if req.limit is set
+    if (req.params.limit) {
+      try {
+        if (parseInt(req.params.limit, 10) > limitPeck) {
+          req.params.limit = limitPeck.toString();
+          res.json({
+            message: `Limit Pecked at ${limitPeck}`,
+          });
+        }
+      } catch (error) {
+        next(CustomError(422, "Invalid limit specified"));
+      }
+    }
+  }
+  next();
+};
+
+module.exports = queryLimitMW;

--- a/middleware/pagination.js
+++ b/middleware/pagination.js
@@ -1,10 +1,10 @@
-const CustomError = require('../utils/customError');
+const CustomError = require("../utils/customError");
 
 exports.queryLimitMW = (req, res, next) => {
   //get limit peck config
   const limitPeck = 50;
   //check if GET request
-  if (req.method === 'GET') {
+  if (req.method === "GET") {
     //check if req.limit is set
     if (req.query.limit) {
       if (parseInt(req.query.limit, 10) > limitPeck) {

--- a/models/comments.js
+++ b/models/comments.js
@@ -1,4 +1,5 @@
 const mongoose = require("mongoose");
+const mongoosePaginate = require("mongoose-paginate-v2");
 const Schema = mongoose.Schema;
 const Replies = require("./replies");
 
@@ -54,6 +55,9 @@ CommentSchema.post("findOneAndDelete", async (comment) => {
     // console.log(`Deleted ${replies.deletedCount} replies`);
   }
 });
+
+//plug in the pagination package
+CommentSchema.plugin(mongoosePaginate);
 
 const Comment = mongoose.model("Comments", CommentSchema);
 module.exports = Comment;

--- a/models/replies.js
+++ b/models/replies.js
@@ -1,4 +1,5 @@
 const mongoose = require("mongoose");
+const mongoosePaginate = require("mongoose-paginate-v2");
 const Schema = mongoose.Schema;
 
 const ReplySchema = new Schema(
@@ -42,6 +43,9 @@ const ReplySchema = new Schema(
   },
   { timestamps: true }
 );
+
+//plug in the pagination package
+ReplySchema.plugin(mongoosePaginate);
 
 const Reply = mongoose.model("Replies", ReplySchema);
 module.exports = Reply;

--- a/package-lock.json
+++ b/package-lock.json
@@ -7564,6 +7564,11 @@
       "resolved": "https://registry.npmjs.org/mongoose-legacy-pluralize/-/mongoose-legacy-pluralize-1.0.2.tgz",
       "integrity": "sha512-Yo/7qQU4/EyIS8YDFSeenIvXxZN+ld7YdV9LqFVQJzTLye8unujAWPZ4NWKfFA+RNjh+wvTWKY9Z3E5XM6ZZiQ=="
     },
+    "mongoose-paginate-v2": {
+      "version": "1.3.9",
+      "resolved": "https://registry.npmjs.org/mongoose-paginate-v2/-/mongoose-paginate-v2-1.3.9.tgz",
+      "integrity": "sha512-KXLmsTYDaS7zHqT45B2MZcCGzJtBySGANor5Xf6c0nU3y34xkRMqcDiVTizLd27KGqy5smqLe6LVNkTK994XGA=="
+    },
     "morgan": {
       "version": "1.10.0",
       "resolved": "https://registry.npmjs.org/morgan/-/morgan-1.10.0.tgz",

--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
     "express-jwt": "^6.0.0",
     "jsonwebtoken": "^8.5.1",
     "mongoose": "^5.9.20",
+    "mongoose-paginate-v2": "^1.3.9",
     "morgan": "^1.10.0",
     "swagger-jsdoc": "^4.0.0",
     "swagger-ui-express": "^4.1.4"

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "server.js",
   "scripts": {
     "start": "node ./bin/www",
-    "startDev": "NODE_ENV=dev nodemon --exec babel-node ./bin/www",
+    "startDev": "nodemon --exec babel-node ./bin/www",
     "test": "cross-env NODE_ENV=test jest --verbose",
     "test:debug": "cross-env NODE_ENV=test jest --detectOpenHandles --verbose",
     "test:watch": "cross-env NODE_ENV=test jest --watch --verbose",

--- a/routes/comments.js
+++ b/routes/comments.js
@@ -4,6 +4,7 @@ const validationMiddleware = require("../middleware/validation");
 const validationRules = require("../utils/validationRules");
 const commentsController = require("../controllers/commentsController");
 const { appAuthMW } = require("../middleware/auth");
+const { queryLimitMW } = require("../middleware/pagination");
 // const mongoose = require("mongoose");
 // const { generateToken } = require("../utils/auth/tokenGenerator");
 
@@ -44,6 +45,7 @@ router.post(
 router.get(
   "/",
   validationMiddleware(validationRules.getAllCommentsSchema),
+  queryLimitMW,
   commentsController.getAllComments
 );
 

--- a/routes/organizations.js
+++ b/routes/organizations.js
@@ -19,5 +19,9 @@ router.post(
   validMW(getOrganizationTokenSchema),
   organizationsController.getSingleOrganizationToken
 );
+/**
+ * DELETE ROUTE
+ */
+router.delete("/:organizationId",validMW(deleteOrganizationSchema),organizationsController.deleteSingleOrganization);
 
 module.exports = router;

--- a/routes/organizations.js
+++ b/routes/organizations.js
@@ -4,6 +4,7 @@ const validMW = require("../middleware/validation");
 const {
   createOrganizationSchema,
   getOrganizationTokenSchema,
+  deleteOrganizationSchema,
 } = require("../utils/validationRules");
 
 /**
@@ -22,6 +23,10 @@ router.post(
 /**
  * DELETE ROUTE
  */
-router.delete("/:organizationId",validMW(deleteOrganizationSchema),organizationsController.deleteSingleOrganization);
+router.delete(
+  "/:organizationId",
+  validMW(deleteOrganizationSchema),
+  organizationsController.deleteSingleOrganization
+);
 
 module.exports = router;

--- a/routes/replies.js
+++ b/routes/replies.js
@@ -2,6 +2,7 @@ const router = require("express").Router({ mergeParams: true });
 const validationMiddleware = require("../middleware/validation");
 const validationRules = require("../utils/validationRules");
 const repliesController = require("../controllers/repliesController");
+const { queryLimitMW } = require("../middleware/pagination");
 
 /**
  * POST routes
@@ -18,6 +19,7 @@ router.post(
 router.get(
   "/",
   validationMiddleware(validationRules.getAllRepliesSchema),
+  queryLimitMW,
   repliesController.getAllReplies
 );
 

--- a/utils/validationRules/organizations/deleteOrganizationSchema.js
+++ b/utils/validationRules/organizations/deleteOrganizationSchema.js
@@ -1,12 +1,12 @@
-const Joi = require('@hapi/joi');
-const mongoIdSchema = require('../mongoIdSchema');
+const Joi = require("@hapi/joi");
+const mongoIdSchema = require("../mongoIdSchema");
 
 /**
  * Schema validation for POST '/organizations/token'
  */
 const deleteOrganizationSchema = {
   params: Joi.object().keys({
-    organizationId: Joi.custom(mongoIdSchema, 'ObjectID').required(),
+    organizationId: Joi.custom(mongoIdSchema, "ObjectID").required(),
   }),
 };
 

--- a/utils/validationRules/organizations/deleteOrganizationSchema.js
+++ b/utils/validationRules/organizations/deleteOrganizationSchema.js
@@ -1,0 +1,13 @@
+const Joi = require('@hapi/joi');
+const mongoIdSchema = require('../mongoIdSchema');
+
+/**
+ * Schema validation for POST '/organizations/token'
+ */
+const deleteOrganizationSchema = {
+  params: Joi.object().keys({
+    organizationId: Joi.custom(mongoIdSchema, 'ObjectID').required(),
+  }),
+};
+
+module.exports = deleteOrganizationSchema;


### PR DESCRIPTION
**Before submitting your PR for review**

- Run `npm run lint` to find errors in code syntax/format
- Run `npm run lint:fix` to fix all auto-fixable errors in source code and auto-format with prettier
- Ensure you fix any linting errors displayed after running any of the above commands

**What does this PR do?**

Fixes #430 

Summarise the main tasks handled in the pull request

**description of Task to be completed?**

- [x] Add `mongoose-paginate-v2` module and add to model schema
- [x] Setup pagination middleware that will check endpoints if limit specified is above system set limit
- [x] Refactor the endpoints controller methods to paginate records
- [x] Write tests to cover functions and query parameters if available
- [x] Write test to cover the pagination middleware

**How should this be manually tested?**
- If PR is merged: 
`https://comments-microservice.herokuapp.com/comments/?page=2&limit=2`

**Any background context you want to provide?**

Any pertinent information that should be considered

**What is the link to the issue on Github?**

[Issue #430](https://github.com/microapidev/comment-microapi/issues/430)

**Questions:**

If something is unclear or you want some questions to be addressed by your peers, mention them here