### PR TITLE
[feature]: Get all microservice admins - GET /msadmins

### DIFF
--- a/__test__/api/msadmins/getAllMsAdmins.test.js
+++ b/__test__/api/msadmins/getAllMsAdmins.test.js
@@ -1,0 +1,81 @@
+const app = require("../../../server");
+const supertest = require("supertest");
+const MsAdmin = require("../../../models/msadmins");
+const request = supertest(app);
+
+// Cached admin.
+let msAdmin;
+
+describe("GET /msAdmins", () => {
+  beforeEach(async () => {
+    // Mock an msAdmin document.
+    msAdmin = new MsAdmin({
+      fullname: "IAmMsAdmin",
+      email: "iammsAdmin@email.org",
+      password: "let me in please",
+    });
+
+    // Save mocked msAdmin document to the database and cache it.
+    await msAdmin.save();
+  });
+
+  afterEach(async () => {
+    // Delete mock from the database.
+    await MsAdmin.findByIdAndDelete(msAdmin._id);
+
+    // Delete cache.
+    msAdmin = null;
+  });
+
+  it("Should get all msAdmins", async () => {
+    let res = await request
+      .get(`/v1/msAdmins`)
+      .set("Authorization", `bearer ${global.superSysToken}`);
+
+    expect(res.status).toEqual(200);
+    expect(res.body.data).toEqual(
+      expect.arrayContaining([
+        {
+          msAdminId: global.msSuperAdmin.id,
+          fullname: global.msSuperAdmin.fullname,
+          email: global.msSuperAdmin.email,
+          role: global.msSuperAdmin.role,
+        },
+        {
+          msAdminId: global.msAdmin.id,
+          fullname: global.msAdmin.fullname,
+          email: global.msAdmin.email,
+          role: global.msAdmin.role,
+        },
+        {
+          msAdminId: msAdmin.id,
+          fullname: msAdmin.fullname,
+          email: msAdmin.email,
+          role: msAdmin.role,
+        },
+      ])
+    );
+  });
+
+  it("Should return a 401 error when authorization token is unauthorized", async () => {
+    const url = `/v1/msAdmins`;
+    const bearerToken = `bearer `;
+
+    const res = await request.get(url).set("Authorization", bearerToken);
+
+    expect(res.status).toEqual(401);
+    expect(res.body.status).toEqual("error");
+    expect(res.body.data).toEqual([]);
+  });
+
+  it("Should return a 401 error when admin token is unauthorized", async () => {
+    const url = `/v1/msAdmins`;
+    const bearerToken = `bearer ${global.sysToken}`;
+
+    const res = await request.get(url).set("Authorization", bearerToken);
+
+    expect(res.status).toEqual(401);
+    expect(res.body.status).toEqual("error");
+    expect(res.body.data).toEqual([]);
+  });
+});

--- a/__test__/config/setup.js
+++ b/__test__/config/setup.js
@@ -84,7 +84,7 @@ beforeAll(async () => {
   global.application = application;
   global.organization = organization;
   global.admin = admin;
-  global.msSuperAdminId = msSuperAdminId;
+  global.msSuperAdmin = await MsAdmin.findById(msSuperAdminId);
   global.msAdmin = msAdmin;
 });
 

--- a/controllers/msAdminsController/getAllMsAdmins.js
+++ b/controllers/msAdminsController/getAllMsAdmins.js
@@ -18,7 +18,7 @@ const getAllMsAdmins = async (req, res, next) => {
     const admins = await MsAdmin.find();
     allMsAdmins = admins.map((admin) => {
       return {
-        adminId: admin._id,
+        msAdminId: admin._id,
         fullname: admin.fullname,
         email: admin.email,
         role: admin.role,

--- a/controllers/msAdminsController/getAllMsAdmins.js
+++ b/controllers/msAdminsController/getAllMsAdmins.js
@@ -1,0 +1,40 @@
+const MsAdmin = require("../../models/msadmins");
+const CustomError = require("../../utils/customError");
+const responseHandler = require("../../utils/responseHandler");
+
+/**
+ * @author David Okanlawon
+ *
+ * Gets all microservice admins.
+ *
+ * @param {*} req - The request object
+ * @param {*} res - The response object
+ * @param {*} next - The function executed to call the next middleware
+ */
+const getAllMsAdmins = async (req, res, next) => {
+  //get all admins mapping the field names appropriately
+  let allMsAdmins;
+  try {
+    const admins = await MsAdmin.find();
+    allMsAdmins = admins.map((admin) => {
+      return {
+        adminId: admin._id,
+        fullname: admin.fullname,
+        email: admin.email,
+        role: admin.role,
+      };
+    });
+  } catch (error) {
+    next(new CustomError(400, "An error occured retrieving admin accounts"));
+    return;
+  }
+
+  return responseHandler(
+    res,
+    200,
+    allMsAdmins,
+    "MsAdmin accounts retrieved successfully"
+  );
+};
+
+module.exports = getAllMsAdmins;

--- a/controllers/msAdminsController/index.js
+++ b/controllers/msAdminsController/index.js
@@ -2,3 +2,4 @@
 exports.createSingleMsAdmin = require("./createSingleMsAdmin");
 exports.loginSysAdmin = require("./loginSysAdmin");
 exports.changeMsAdminPassword = require("./changeMsAdminPassword");
+exports.getAllMsAdmins = require("./getAllMsAdmins");

--- a/middleware/auth.js
+++ b/middleware/auth.js
@@ -1,5 +1,6 @@
 const jwtMW = require("express-jwt");
 require("dotenv").config();
+const CustomError = require("../utils/customError");
 
 const credsRequired = process.env.DISABLE_AUTH.toLowerCase() === "true";
 
@@ -23,3 +24,12 @@ exports.sysAuthMW = jwtMW({
   algorithms: ["HS256"],
   credentialsRequired: credsRequired,
 });
+
+//middleware to prevent non-superadmins to the routes below
+exports.superAdminMW = (req, res, next) => {
+  if (req.token.role !== "superadmin") {
+    return next(new CustomError(401, "Unauthorized access. Access denied!"));
+  }
+
+  next();
+};

--- a/routes/msadmins.js
+++ b/routes/msadmins.js
@@ -3,10 +3,11 @@ const { sysAuthMW } = require("../middleware/auth");
 const msAdminsCtrl = require("../controllers/msAdminsController");
 const validMW = require("../middleware/validation");
 const validationRules = require("../utils/validationRules").msAdmins;
+const CustomError = require("../utils/customError");
 
 const router = express.Router();
 
-// ------- Unguarded routes ----------
+// ------- Unguarded/open routes ----------
 router.post(
   "/login",
   validMW(validationRules.loginAdminSchema),
@@ -32,6 +33,17 @@ router.post(
   validMW(validationRules.changeMsAdminPasswordSchema),
   msAdminsCtrl.changeMsAdminPassword
 );
+
+//------------SUPERADMIN Routes---------------
+
+//middleware to prevent non-superadmins to the routes below
+router.use((req, res, next) => {
+  if (req.token.role !== "superadmin") {
+    return next(new CustomError(401, "Unauthorized access. Access denied!"));
+  }
+
+  next();
+});
 
 /**
  * GET routes

--- a/routes/msadmins.js
+++ b/routes/msadmins.js
@@ -40,6 +40,11 @@ router.use(superAdminMW);
 /**
  * GET routes
  */
+router.get(
+  "/",
+  validMW(validationRules.getAllMsAdminsSchema),
+  msAdminsCtrl.getAllMsAdmins
+);
 
 /**
  * PATCH routes

--- a/routes/msadmins.js
+++ b/routes/msadmins.js
@@ -1,9 +1,8 @@
 const express = require("express");
-const { sysAuthMW } = require("../middleware/auth");
+const { sysAuthMW, superAdminMW } = require("../middleware/auth");
 const msAdminsCtrl = require("../controllers/msAdminsController");
 const validMW = require("../middleware/validation");
 const validationRules = require("../utils/validationRules").msAdmins;
-const CustomError = require("../utils/customError");
 
 const router = express.Router();
 
@@ -35,15 +34,8 @@ router.post(
 );
 
 //------------SUPERADMIN Routes---------------
-
-//middleware to prevent non-superadmins to the routes below
-router.use((req, res, next) => {
-  if (req.token.role !== "superadmin") {
-    return next(new CustomError(401, "Unauthorized access. Access denied!"));
-  }
-
-  next();
-});
+//middleware to block non-superadmin roles
+router.use(superAdminMW);
 
 /**
  * GET routes

--- a/utils/validationRules/msadmins/getAllMsAdminsSchema.js
+++ b/utils/validationRules/msadmins/getAllMsAdminsSchema.js
@@ -1,0 +1,12 @@
+const Joi = require("@hapi/joi");
+
+/**
+ * Schema validation for GET '/msadmins'
+ */
+const getAllMsAdminsSchema = {
+  headers: Joi.object({
+    authorization: Joi.string().required(),
+  }),
+};
+
+module.exports = getAllMsAdminsSchema;

--- a/utils/validationRules/msadmins/index.js
+++ b/utils/validationRules/msadmins/index.js
@@ -1,3 +1,4 @@
 exports.createSingleMsAdminSchema = require("./createSingleMsAdminSchema");
 exports.loginAdminSchema = require("./loginAdminSchema");
 exports.changeMsAdminPasswordSchema = require("./changeMsAdminPasswordSchema");
+exports.getAllMsAdminsSchema = require("./getAllMsAdminsSchema");


### PR DESCRIPTION
**Before submitting your PR for review**

- Run `npm run lint` to find errors in code syntax/format
- Run `npm run lint:fix` to fix all auto-fixable errors in source code and auto-format with prettier
- Ensure you fix any linting errors displayed after running any of the above commands

**What does this PR do?**

Fixes #436 

An endpoint to get all microservice admins

**Description of Task to be completed?**
- Create controller for getting all system admins
- Add validation rules and middleware
- Attach controller to route
- Write tests for the endpoint

**How should this be manually tested?**

- Send GET request to `/v1/msadmins` with a valid superAdmin system token

**Any background context you want to provide?**

Only superAdmins can access this endpoint