### PR TITLE
[hotfix]: temp default superadmin email and password

### DIFF
--- a/__test__/utils/auth/msadmin.test.js
+++ b/__test__/utils/auth/msadmin.test.js
@@ -3,18 +3,18 @@ const MsAdmin = require("../../../models/msadmins");
 
 describe("MsAdmin auth utils", () => {
   describe("createDefaultAdmin", () => {
-    /* it("should throw error if SUPER_ADMIN_EMAIL not found", async () => {
+    it.skip("should throw error if SUPER_ADMIN_EMAIL not found", async () => {
       process.env.SUPER_ADMIN_PASSWORD = "password";
       process.env.SUPER_ADMIN_EMAIL = "";
       await expect(createDefaultAdmin()).rejects.toThrow();
     });
 
-    it("should throw error if SUPER_ADMIN_PASSWORD not found", async () => {
+    it.skip("should throw error if SUPER_ADMIN_PASSWORD not found", async () => {
       process.env.SUPER_ADMIN_EMAIL = "test@email.com";
       process.env.SUPER_ADMIN_PASSWORD = "";
       await expect(createDefaultAdmin()).rejects.toThrow();
     });
- */
+
     it("should create default admin", async () => {
       process.env.SUPER_ADMIN_EMAIL = "test@email.com";
       process.env.SUPER_ADMIN_PASSWORD = "password";

--- a/utils/auth/msadmin.js
+++ b/utils/auth/msadmin.js
@@ -24,7 +24,9 @@ exports.createDefaultAdmin = async () => {
     log("\n \t Minimal account not found ... creating");
 
     //check email
-    const superAdminEmail = process.env.SUPER_ADMIN_EMAIL;
+    //putting a temp default email and password in production future this has to be r
+    const superAdminEmail =
+      process.env.SUPER_ADMIN_EMAIL || "superadmin@microapi.dev";
 
     //if no password found exit requesting the variable
     if (!superAdminEmail) {
@@ -34,7 +36,7 @@ exports.createDefaultAdmin = async () => {
     }
 
     //check password
-    const superAdminPassword = process.env.SUPER_ADMIN_PASSWORD;
+    const superAdminPassword = process.env.SUPER_ADMIN_PASSWORD || "superadmin";
 
     //if no password found exit requesting the variable
     if (!superAdminPassword) {


### PR DESCRIPTION
**Before submitting your PR for review**

- Run `npm run lint` to find errors in code syntax/format
- Run `npm run lint:fix` to fix all auto-fixable errors in source code and auto-format with prettier
- Ensure you fix any linting errors displayed after running any of the above commands

**What does this PR do?**
For system setups where no .ENV variable is set, for now we are making this temp bypass and assigning default values to the superadmin account. Should be removed in future releases