### PR TITLE
feat: add email to response body of get organization(s)

### DIFF
--- a/controllers/msAdminsController/organizations/getAllOrganizations.js
+++ b/controllers/msAdminsController/organizations/getAllOrganizations.js
@@ -28,6 +28,7 @@ const getAllOrganizations = async (req, res, next) => {
       return {
         organizationId: organization._id,
         organizationName: organization.name,
+        organizationEmail: organization.email,
       };
     });
 

--- a/controllers/msAdminsController/organizations/getSingleOrganization.js
+++ b/controllers/msAdminsController/organizations/getSingleOrganization.js
@@ -41,6 +41,7 @@ const getSingleOrganization = async (req, res, next) => {
     organization = {
       organizationId: singleOrganization._id,
       organizationName: singleOrganization.name,
+      organizationEmail: singleOrganization.email,
     };
   } catch (error) {
     next(new CustomError(400, "An error occured retrieving organization"));

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -716,6 +716,8 @@ paths:
                               type: string
                             organizationName:
                               type: string
+                            organizationEmail:
+                              type: string
 
         "400":
           description: Bad request error
@@ -776,6 +778,8 @@ paths:
                       organizationId:
                         type: string
                       organizationName:
+                        type: string
+                      organizationEmail:
                         type: string
 
         "400":


### PR DESCRIPTION
**Before submitting your PR for review**

- Run `npm run lint` to find errors in code syntax/format
- Run `npm run lint:fix` to fix all auto-fixable errors in source code and auto-format with prettier
- Ensure you fix any linting errors displayed after running any of the above commands

**What does this PR do?**

It includes the email property of organizations in the response body for msadmins GET requests.

**description of Task to be completed?**

- [x] Include `organizationEmail` property for GET /msadmins/organizations
- [x] Include `organizationEmail` property for GET /msadmins/organizations/:organizationId
- [x] Update swagger documentation to reflect new changes

**How should this be manually tested?**

In your terminal, run `npm start`.
- On postman, with the correct system admin token, make a GET to the endpoints.

**Any background context you want to provide?**

This will allow the admin dashboard to be able to show the emails of organizations.

**What is the link to the issue on Github?**

None

**Questions:**

None